### PR TITLE
Uart mode tests

### DIFF
--- a/dist/robotframework/lib/PhilipAPI.py
+++ b/dist/robotframework/lib/PhilipAPI.py
@@ -13,8 +13,8 @@ class PhilipAPI(Phil):
         super().__init__(port, baudrate)
 
     def setup_uart(self, mode=0, baudrate=115200,
-                   parity=serial.PARITY_NONE, stopbits=serial.STOPBITS_ONE,
-                   rts=True):
+                   databits=serial.EIGHTBITS, parity=serial.PARITY_NONE,
+                   stopbits=serial.STOPBITS_ONE, rts=True):
         """Setup tester's UART."""
         ret = list()
         mode = int(mode)
@@ -23,6 +23,9 @@ class PhilipAPI(Phil):
         ret.append(self.write_reg('uart.baud', int(baudrate)))
 
         # setup UART control register
+        if databits == serial.SEVENBITS:
+            ret.append(self.write_reg('uart.mode.data_bits', 1))
+
         if parity == serial.PARITY_EVEN:
             ret.append(self.write_reg('uart.mode.parity', 1))
         elif parity == serial.PARITY_ODD:
@@ -38,4 +41,20 @@ class PhilipAPI(Phil):
 
         # apply changes
         ret.append(self.execute_changes())
+        return ret
+
+    def get_counters(self):
+        """Get rx/tx counters."""
+        ret = list()
+        ret.append(self.read_reg('uart.rx_count'))
+        ret.append(self.read_reg('uart.tx_count'))
+        return ret
+
+    def get_error_flags(self):
+        """Get error flags."""
+        ret = list()
+        ret.append(self.read_reg('uart.status.pe'))
+        ret.append(self.read_reg('uart.status.fe'))
+        ret.append(self.read_reg('uart.status.nf'))
+        ret.append(self.read_reg('uart.status.ore'))
         return ret

--- a/dist/robotframework/res/philip.keywords.txt
+++ b/dist/robotframework/res/philip.keywords.txt
@@ -9,3 +9,15 @@ Reset DUT and PHILIP
     Reset Application
     PHILIP.Reset MCU
     PHILIP.DuT Reset
+
+Show PHILIP Statistics
+    [Documentation]     Show rx/tx counters and error flags.
+    ${rx}   ${tx} =  PHILIP.Get counters
+    ${pe}   ${fe}   ${nf}   ${ore} =  PHILIP.Get error flags
+    Set Test Message   RX: ${rx['data']}, TX: ${tx['data']}, PE: ${pe['data']}, FE: ${fe['data']}, NF: ${nf['data']}, ORE: ${ore['data']}
+
+Get PHILIP Statistics
+    [Documentation]     Return rx/tx counters and error flags.
+    ${rx}   ${tx}=                    PHILIP.Get counters
+    ${pe}   ${fe}   ${nf}   ${ore}=   PHILIP.Get error flags
+    [return]                          RX: ${rx['data']}, TX: ${tx['data']}, PE: ${pe['data']}, FE: ${fe['data']}, NF: ${nf['data']}, ORE: ${ore['data']}

--- a/tests/periph_uart/tests/01__periph_uart_base.robot
+++ b/tests/periph_uart/tests/01__periph_uart_base.robot
@@ -15,42 +15,55 @@ Force Tags          periph  uart
 Echo
     API Call Should Succeed     Uart Init
     PHILIP.Setup Uart
-    API Call Should Succeed     Uart Send String      ${SHORT_TEST_STRING}
-    Should Be Equal             ${RESULT['data'][0]}  ${SHORT_TEST_STRING}
+    DUT Should Match String     1  ${SHORT_TEST_STRING}  ${SHORT_TEST_STRING}
+    Show PHILIP Statistics
 
 Long Echo
     API Call Should Succeed     Uart Init
     PHILIP.Setup Uart
-    API Call Should Succeed     Uart Send String      ${LONG_TEST_STRING}
-    Should Be Equal             ${RESULT['data'][0]}  ${LONG_TEST_STRING}
+    DUT Should Match String     1  ${LONG_TEST_STRING}  ${LONG_TEST_STRING}
+    Show PHILIP Statistics
 
 Extended Echo
     API Call Should Succeed     Uart Init
     PHILIP.Setup Uart           mode=1
-    API Call Should Succeed     Uart Send String      ${SHORT_TEST_STRING}
-    Should Be Equal             ${RESULT['data'][0]}  ${SHORT_TEST_STRING_INC}
+    DUT Should Match String     1  ${SHORT_TEST_STRING}  ${SHORT_TEST_STRING_INC}
+    Show PHILIP Statistics
 
 Extended Long Echo
     API Call Should Succeed     Uart Init
     PHILIP.Setup Uart           mode=1
-    API Call Should Succeed     Uart Send String      ${LONG_TEST_STRING}
-    Should Be Equal             ${RESULT['data'][0]}  ${LONG_TEST_STRING_INC}
+    DUT Should Match String     1  ${LONG_TEST_STRING}  ${LONG_TEST_STRING_INC}
+    Show PHILIP Statistics
 
 Register Access
     API Call Should Succeed     Uart Init
     PHILIP.Setup Uart           mode=2
-    API Call Should Succeed     Uart Send String      ${REG_USER_READ}
-    Should Be Equal             ${RESULT['data']}     ${REG_USER_READ_DATA}
+    API Call Should Succeed     Uart Send String   ${REG_USER_READ}
+    Should Be Equal             ${RESULT['data']}  ${REG_USER_READ_DATA}
+    Show PHILIP Statistics
 
 Should Not Access Invalid Register
     API Call Should Succeed     Uart Init
     PHILIP.Setup Uart           mode=2
     API Call Should Succeed     Uart Send String      ${REG_WRONG_READ}
     Should Be Equal             ${RESULT['data']}     ${REG_WRONG_READ_DATA}
+    Show PHILIP Statistics
 
-Baud Test
-    API Call Should Succeed     Uart Init
-    PHILIP.Setup Uart           mode=1
-    API Call Should Succeed     Uart Send String      ${SHORT_TEST_STRING}
+Baud Test 38400
     API Call Should Succeed     Uart Init             baud=${38400}
-    API Call Should Timeout     Uart Send String      ${SHORT_TEST_STRING}
+    PHILIP.Setup Uart           baudrate=38400
+    DUT Should Match String     1  ${SHORT_TEST_STRING}  ${SHORT_TEST_STRING}
+    Show PHILIP Statistics
+
+Baud Test 9600
+    API Call Should Succeed     Uart Init             baud=${9600}
+    PHILIP.Setup Uart           baudrate=9600
+    DUT Should Match String     1  ${SHORT_TEST_STRING}  ${SHORT_TEST_STRING}
+    Show PHILIP Statistics
+
+Wrong Baud Test
+    API Call Should Succeed     Uart Init             baud=${38400}
+    PHILIP.Setup Uart
+    DUT Should Not Match String or Timeout   1  ${SHORT_TEST_STRING}  ${SHORT_TEST_STRING}
+    Show PHILIP Statistics

--- a/tests/periph_uart/tests/02__periph_uart_mode.robot
+++ b/tests/periph_uart/tests/02__periph_uart_mode.robot
@@ -1,0 +1,63 @@
+*** Settings ***
+Suite Setup         Run Keywords    Reset DUT and PHILIP
+...                                 DUT Must Have Periph UART Application
+Test Setup          Run Keywords    Reset DUT and PHILIP
+...                                 DUT Must Have Periph UART Application
+
+Resource            periph_uart.keywords.txt
+Resource            api_shell.keywords.txt
+
+Variables           test_vars.py
+
+Force Tags          periph  uart
+
+*** Test Cases ***
+Even Parity 8 Bits
+    DUT UART mode should exist  dev=1
+    PHILIP.Setup Uart		parity=${UART_PARITY_EVEN}
+    API Call Should Succeed     Uart Init
+    API Call Should Succeed     Uart Mode             data_bits=8   parity="E"   stop_bits=1
+    DUT Should Match String     1  ${SHORT_TEST_STRING}  ${SHORT_TEST_STRING}
+    API Call Should Succeed     Uart Mode             data_bits=8   parity="O"   stop_bits=1
+    DUT Should Not Match String or Timeout     1   ${SHORT_TEST_STRING}   ${SHORT_TEST_STRING}
+    Show PHILIP Statistics
+
+Odd Parity 8 Bits
+    DUT UART mode should exist  dev=1
+    PHILIP.Setup Uart		parity=${UART_PARITY_ODD}
+    API Call Should Succeed     Uart Init
+    API Call Should Succeed     Uart Mode             data_bits=8   parity="O"   stop_bits=1
+    DUT Should Match String     1  ${SHORT_TEST_STRING}  ${SHORT_TEST_STRING}
+    API Call Should Succeed     Uart Mode             data_bits=8   parity="E"   stop_bits=1
+    DUT Should Not Match String or Timeout     1   ${SHORT_TEST_STRING}   ${SHORT_TEST_STRING}
+    Show PHILIP Statistics
+
+Even Parity 7 Bits
+    DUT UART mode should exist  dev=1
+    PHILIP.Setup Uart		parity=${UART_PARITY_EVEN}   databits=${UART_DATA_BITS_7}
+    API Call Should Succeed     Uart Init
+    API Call Should Succeed     Uart Mode             data_bits=7   parity="E"   stop_bits=1
+    DUT Should Match String     1  ${SHORT_TEST_STRING}  ${SHORT_TEST_STRING}
+    API Call Should Succeed     Uart Mode             data_bits=7   parity="O"   stop_bits=1
+    DUT Should Not Match String or Timeout     1   ${SHORT_TEST_STRING}   ${SHORT_TEST_STRING}
+    Show PHILIP Statistics
+
+Odd Parity 7 Bits
+    DUT UART mode should exist  dev=1
+    PHILIP.Setup Uart		parity=${UART_PARITY_ODD}   databits=${UART_DATA_BITS_7}
+    API Call Should Succeed     Uart Init
+    API Call Should Succeed     Uart Mode             data_bits=7   parity="O"   stop_bits=1
+    DUT Should Match String     1  ${SHORT_TEST_STRING}  ${SHORT_TEST_STRING}
+    API Call Should Succeed     Uart Mode             data_bits=7   parity="E"   stop_bits=1
+    DUT Should Not Match String or Timeout     1   ${SHORT_TEST_STRING}   ${SHORT_TEST_STRING}
+    Show PHILIP Statistics
+
+Two Stop Bits
+    DUT UART mode should exist  dev=1
+    PHILIP.Setup Uart		parity=${UART_PARITY_ODD}
+    API Call Should Succeed     Uart Init
+    API Call Should Succeed     Uart Mode             data_bits=8   parity="N"   stop_bits=2
+    DUT Should Match String     1  ${TEST_STRING_FOR_STOP_BITS}  ${TEST_STRING_FOR_STOP_BITS}
+    API Call Should Succeed     Uart Mode             data_bits=8   parity="N"   stop_bits=1
+    DUT Should Not Match String or Timeout     1   ${TEST_STRING_FOR_STOP_BITS}   ${TEST_STRING_FOR_STOP_BITS}
+    Show PHILIP Statistics

--- a/tests/periph_uart/tests/periph_uart.keywords.txt
+++ b/tests/periph_uart/tests/periph_uart.keywords.txt
@@ -1,5 +1,6 @@
 *** Settings ***
 Library             UartDevice  port=%{PORT}  baudrate=%{BAUD}  timeout=${10}
+Library             periph_uart_if.PeriphUartUtil
 
 Resource            api_shell.keywords.txt
 Resource            philip.keywords.txt
@@ -10,6 +11,21 @@ DUT Must Have Periph UART Application
     Should Contain              ${RESULT['msg']}  periph_uart
 
 DUT Should Match String
-    [Arguments]                 ${dev}  ${test_string}
-    API Call Should Succeed     Uart Send  dev=${dev}  test_string=${test_string}
-    Should Be Equal             ${RESULT['data']}  ${test_string}
+    [Arguments]                 ${dev}  ${test_string}  ${reference_string}
+    ${RESULT}=                  Run Keyword  Uart Send String   dev=${dev}  test_string=${test_string}
+    ${stat}=                    Get PHILIP Statistics
+    ${err_msg}=                 Message for should match   ${RESULT}   ${reference_string}   ${stat}
+    Should Be Empty             ${err_msg}   ${err_msg}
+
+DUT Should Not Match String or Timeout
+    [Arguments]                 ${dev}  ${test_string}  ${reference_string}
+    ${RESULT}=                  Run Keyword  Uart Send String   dev=${dev}  test_string=${test_string}
+    ${stat}=                    Get PHILIP Statistics
+    ${err_msg}=                 Message for should not match   ${RESULT}   ${reference_string}   ${stat}
+    #Should Be True              '${RESULT['result']}'=='Timeout' or '${rcv_string}'!='${reference_string}'   msg=${stat}
+    Should Be Empty             ${err_msg}   ${err_msg}
+
+DUT UART mode should exist
+    [Arguments]                 ${dev}
+    ${status}   ${value}=       Run Keyword And Ignore Error   API Call Should Succeed   Uart Mode   dev=${dev}   data_bits=8   parity="N"   stop_bits=1
+    Pass Execution If           '${status}'=='FAIL'   Feature is not supported

--- a/tests/periph_uart/tests/periph_uart_if.py
+++ b/tests/periph_uart/tests/periph_uart_if.py
@@ -31,3 +31,41 @@ class PeriphUartIf(DutShell):
     def uart_get_id(self):
         """Get the id of the fw."""
         return self.send_cmd('uart_get_id')
+
+
+class PeriphUartUtil(object):
+    """Helper class for error message handling."""
+
+    @staticmethod
+    def uart_get_string(result):
+        """Return either an empty string if sending failed or received one."""
+        rcv_string = ''
+        if result['data'] is not None and result['data'][0]:
+            rcv_string = result['data'][0]
+
+        return rcv_string
+
+    def message_for_should_match(self, result, ref_string, stats):
+        """Create message for DUT Should Match String keyword."""
+        ret = ''
+        rcv_string = self.uart_get_string(result)
+        if result['result'] == 'Timeout':
+            ret = "Test timed out: " + stats
+        elif result['result'] == 'Success' and rcv_string != ref_string:
+            ret = "Reference string doesn't match the received one: " + stats
+        elif result['result'] == 'Error':
+            ret = "API call failed: " + result['msg']
+
+        return ret
+
+    def message_for_should_not_match(self, result, ref_string, stats):
+        """Create message for DUT Should Not Match String keyword."""
+        ret = ''
+        rcv_string = self.uart_get_string(result)
+        if result['result'] == 'Success' and rcv_string == ref_string:
+            ret = "No timeout occurred and the reference string " \
+                  "does match the received one: " + stats
+        elif result['result'] == 'Error':
+            ret = "API call failed: " + result['msg']
+
+        return ret

--- a/tests/periph_uart/tests/test_vars.py
+++ b/tests/periph_uart/tests/test_vars.py
@@ -1,6 +1,7 @@
 import errno
 import random
 import string
+import serial
 
 
 def increment_data(data):
@@ -23,3 +24,13 @@ REG_USER_READ = "\"rr 0 10\""
 REG_USER_READ_DATA = ['{"data":[0,1,2,3,4,5,6,7,8,9']
 REG_WRONG_READ = "\"rr -1 10\""
 REG_WRONG_READ_DATA = ['{"result":22}']
+
+UART_DATA_BITS_7 = serial.SEVENBITS
+UART_DATA_BITS_8 = serial.EIGHTBITS
+
+UART_PARITY_NONE = serial.PARITY_NONE
+UART_PARITY_EVEN = serial.PARITY_EVEN
+UART_PARITY_ODD = serial.PARITY_ODD
+
+UART_STOP_BITS_1 = serial.STOPBITS_ONE
+UART_STOP_BITS_2 = serial.STOPBITS_TWO

--- a/tests/periph_uart/tests/test_vars.py
+++ b/tests/periph_uart/tests/test_vars.py
@@ -15,6 +15,7 @@ def create_random_data(data_len):
         string.digits) for n in range(data_len)])
 
 
+TEST_STRING_FOR_STOP_BITS = "tttt"
 SHORT_TEST_STRING = "t111"
 SHORT_TEST_STRING_INC = increment_data(SHORT_TEST_STRING)
 LONG_TEST_STRING = create_random_data(42)


### PR DESCRIPTION
Add support for new UART API call `uart_mode`.

Before performing these new tests, the DUT will be checked whether `uart_mode` is supported. If not, the test will be marked as **PASS** with a note "Feature is not supported".