### PR TITLE
fix(i2c): Remove invalid i2c tests

### DIFF
--- a/tests/periph_i2c/tests/01__periph_i2c_base.robot
+++ b/tests/periph_i2c/tests/01__periph_i2c_base.robot
@@ -28,16 +28,6 @@ Double Acquire Should Timeout
     API Call Should Succeed     I2C Acquire
     API Call Should Timeout     I2C Acquire
 
-Unacquired Read Register Should Succeed
-    [Documentation]             Verfiy reading a register without acquiring the I2C bus.
-    API Call Should Succeed     I2C Read Reg
-
-Read Register After Release Should Error
-    [Documentation]             Verfiy reading a register doesn't work after releasing the I2C bus.
-    API Call Should Succeed     I2C Acquire
-    API Call Should Succeed     I2C Release
-    API Call Should Error       I2C Read Reg
-
 Read Register After NACK Should Succeed
     [Documentation]             Verify recovery of I2C bus after NACK.
     API Call Should Error       I2C Read Reg  addr=42


### PR DESCRIPTION
The tests are currently testing an undefined state
Any i2c action must be acquired

Currently the HiL is reporting errors in an undefined state.  RIOT does not guarantee the i2c state if unacquired, some cpus may work and some may not.  To make it consistent extra bytes are needed and unnecessary if the documentation is followed.