### PR TITLE
fix(i2c): Add i2c acquire and release to NACK check

### DIFF
--- a/tests/periph_i2c/tests/01__periph_i2c_base.robot
+++ b/tests/periph_i2c/tests/01__periph_i2c_base.robot
@@ -30,5 +30,7 @@ Double Acquire Should Timeout
 
 Read Register After NACK Should Succeed
     [Documentation]             Verify recovery of I2C bus after NACK.
+    API Call Should Succeed     I2C Acquire
     API Call Should Error       I2C Read Reg  addr=42
     API Call Should Succeed     I2C Read Reg
+    API Call Should Succeed     I2C Release


### PR DESCRIPTION
Since we must acquire before doing anything with the bus the test is wrong.  This should fix it and also fix the failing frdm-k22f board in the HiL

Fixes #3 