### PR TITLE
Make: sort robot files

### DIFF
--- a/dist/robotframework/Makefile.include
+++ b/dist/robotframework/Makefile.include
@@ -3,7 +3,7 @@ RFBASE    ?= $(TESTBASE)/dist/robotframework
 RFPYPATH  ?= $(APPDIR)/tests:$(RFBASE)/lib:$(RFBASE)/res
 RFOUTPATH ?= $(BUILD_DIR)/robot/$(BOARD)/$(APPLICATION)/
 # search for RF test script files
-ROBOT_FILES ?= $(wildcard tests/*.robot)
+ROBOT_FILES ?= $(sort $(wildcard tests/*.robot))
 # RF make target
 robot-test: $(ROBOT_FILES)
 	python3 -m robot.run \


### PR DESCRIPTION
Without the sort command, the robot files are invoked in arbitrary order.

Signed-off-by: Yegor Yefremov <yegorslists@googlemail.com>