### PR TITLE
feature(i2c): Add read bytes nack test

### DIFF
--- a/tests/periph_i2c/tests/01__periph_i2c_base.robot
+++ b/tests/periph_i2c/tests/01__periph_i2c_base.robot
@@ -34,3 +34,11 @@ Read Register After NACK Should Succeed
     API Call Should Error       I2C Read Reg  addr=42
     API Call Should Succeed     I2C Read Reg
     API Call Should Succeed     I2C Release
+
+Read Byte After Multiple NACKs Should Succeed
+    [Documentation]             Verify recovery of read bytes NACK.
+    API Call Should Succeed     I2C Acquire
+    API Call Should Error       I2C Read Byte  addr=42
+    API Call Should Error       I2C Read Byte  addr=43
+    API Call Should Succeed     I2C Read Byte
+    API Call Should Succeed     I2C Release


### PR DESCRIPTION
A bug was found when multiple nacks due to read bytes were issued.
This test identifies this bug by reading the incorrect bytes
multiple times then trying to recover with read byte.