### PR TITLE
tests: generalise reset keyword

### DIFF
--- a/dist/robotframework/README.md
+++ b/dist/robotframework/README.md
@@ -10,7 +10,7 @@ or writing any test install the package by calling:
 pip install robotframework
 ```
 
-There is also a `requirements.txt` which also installs the `riot_pal` package
+There is also a `requirements.txt` which also installs more Python packages
 for HIL tests, to install all at once, run:
 
 ```

--- a/dist/robotframework/requirements.txt
+++ b/dist/robotframework/requirements.txt
@@ -1,3 +1,3 @@
 robotframework
-riot_pal==0.2.2
-
+riot_pal>=0.2.3
+philip_pal>=1.1.0

--- a/dist/robotframework/res/philip.keywords.txt
+++ b/dist/robotframework/res/philip.keywords.txt
@@ -4,11 +4,9 @@ Library             PhilipAPI  port=%{PHILIP_PORT}  baudrate=${115200}  WITH NAM
 Resource            riot_base.keywords.txt
 
 *** Keywords ***
-Reset DUT and PHILIP
-    [Documentation]     Reset the device under test and the PHILIP tester.
-    Reset Application
+PHILIP Reset
+    [Documentation]     Reset the PHiLIP MCU
     PHILIP.Reset MCU
-    PHILIP.DuT Reset
 
 Show PHILIP Statistics
     [Documentation]     Show rx/tx counters and error flags.

--- a/dist/robotframework/res/riot_base.keywords.txt
+++ b/dist/robotframework/res/riot_base.keywords.txt
@@ -7,10 +7,10 @@ Library     Collections
 *** Variables ***
 ${RIOTTOOLS}            %{RIOTBASE}/dist/tools
 
+
 *** Keywords ***
-Reset Application
+RIOT Reset
     [Documentation]     Reset the test application
-    [Arguments]         ${sleep_before}=3  ${sleep_after}=3
-    Sleep               ${sleep_before}
+    ${sleep_after}=     Get Environment Variable  RESET_WAIT  default=3
     Run Process         make reset  shell=True  cwd=%{APPDIR}
     Sleep               ${sleep_after}

--- a/tests/periph_i2c/tests/01__periph_i2c_base.robot
+++ b/tests/periph_i2c/tests/01__periph_i2c_base.robot
@@ -1,10 +1,11 @@
 *** Settings ***
 Documentation       Verify basic functionality of the periph I2C API.
 
-Suite Setup         Run Keywords    Reset DUT and PHILIP
+Suite Setup         Run Keywords    RIOT Reset
+...                                 PHILIP Reset
 ...                                 API Firmware Should Match
-Test Setup          Run Keywords    Reset DUT and PHILIP
-...                                 API Firmware Should Match
+Test Setup          Run Keywords    RIOT Reset
+...                                 PHILIP Reset
 
 Resource            periph_i2c.keywords.txt
 Resource            api_shell.keywords.txt

--- a/tests/periph_i2c/tests/02__periph_i2c_write_register.robot
+++ b/tests/periph_i2c/tests/02__periph_i2c_write_register.robot
@@ -1,10 +1,11 @@
 *** Settings ***
 Documentation       Data driven tests to verify the i2c_write_regs call.
 
-Suite Setup         Run Keywords    Reset DUT and PHILIP
+Suite Setup         Run Keywords    RIOT Reset
+...                                 PHILIP Reset
 ...                                 API Firmware Should Match
-Test Setup          Run Keywords    Reset DUT and PHILIP
-...                                 API Firmware Should Match
+Test Setup          Run Keywords    RIOT Reset
+...                                 PHILIP Reset
 ...                                 I2C Acquire
 Test Teardown       I2C Release
 Test Template       I2C Write Bytes To Register Should Succeed

--- a/tests/periph_i2c/tests/03__periph_i2c_error_codes.robot
+++ b/tests/periph_i2c/tests/03__periph_i2c_error_codes.robot
@@ -1,10 +1,11 @@
 *** Settings ***
 Documentation       Tests to verify correct error codes are given.
 
-Suite Setup         Run Keywords    Reset DUT and PHILIP
+Suite Setup         Run Keywords    RIOT Reset
+...                                 PHILIP Reset
 ...                                 API Firmware Should Match
-Test Setup          Run Keywords    Reset DUT and PHILIP
-...                                 API Firmware Should Match
+Test Setup          Run Keywords    RIOT Reset
+...                                 PHILIP Reset
 ...                                 I2C Acquire
 Test Teardown       I2C Release
 

--- a/tests/periph_uart/tests/01__periph_uart_base.robot
+++ b/tests/periph_uart/tests/01__periph_uart_base.robot
@@ -1,10 +1,11 @@
 *** Settings ***
 Documentation       Verify basic functionality of the periph UART API.
 
-Suite Setup         Run Keywords    Reset DUT and PHILIP
+Suite Setup         Run Keywords    RIOT Reset
+...                                 PHILIP Reset
 ...                                 API Firmware Should Match
-Test Setup          Run Keywords    Reset DUT and PHILIP
-...                                 API Firmware Should Match
+Test Setup          Run Keywords    RIOT Reset
+...                                 PHILIP Reset
 
 Resource            periph_uart.keywords.txt
 Resource            api_shell.keywords.txt

--- a/tests/periph_uart/tests/02__periph_uart_mode.robot
+++ b/tests/periph_uart/tests/02__periph_uart_mode.robot
@@ -1,10 +1,11 @@
 *** Settings ***
 Documentation       Verify mode config functionality of the periph UART API.
 
-Suite Setup         Run Keywords    Reset DUT and PHILIP
+Suite Setup         Run Keywords    RIOT Reset
+...                                 PHILIP Reset
 ...                                 API Firmware Should Match
-Test Setup          Run Keywords    Reset DUT and PHILIP
-...                                 API Firmware Should Match
+Test Setup          Run Keywords    RIOT Reset
+...                                 PHILIP Reset
 
 Resource            periph_uart.keywords.txt
 Resource            api_shell.keywords.txt

--- a/tests/xtimer_cli/tests/01__xtimer_base.robot
+++ b/tests/xtimer_cli/tests/01__xtimer_base.robot
@@ -2,11 +2,10 @@
 Documentation       Verify basic functionality of the Xtimer API.
 
 # reset application and check DUT has correct firmware, skip all tests on error
-Suite Setup         Run Keywords    Reset Application
+Suite Setup         Run Keywords    RIOT Reset
 ...                                 API Firmware Should Match
-# reset application and check DUT is up again befor every test case
-Test Setup          Run Keywords    Reset Application
-...                                 API Firmware Should Match
+# reset application before running any test
+Test Setup          Run Keywords    RIOT Reset
 
 # import libs and keywords
 Library             Xtimer  port=%{PORT}  baudrate=%{BAUD}  timeout=${10}


### PR DESCRIPTION
This PR removes a special (Philip based) reset command and relies on `make reset` provided by RIOT which can be replaces by setting env variables if needed.

Also renames the other reset command to reflect that it uses RIOT.