### PR TITLE
tests/uart: improve robustness of uart tests

### DIFF
--- a/tests/periph_uart/tests/01__periph_uart_base.robot
+++ b/tests/periph_uart/tests/01__periph_uart_base.robot
@@ -16,57 +16,57 @@ Force Tags          periph  uart
 
 *** Test Cases ***
 Echo
-    API Call Should Succeed     Uart Init
     PHILIP.Setup Uart
+    API Call Should Succeed     Uart Init
     DUT Should Match String     1  ${SHORT_TEST_STRING}  ${SHORT_TEST_STRING}
     Show PHILIP Statistics
 
 Long Echo
-    API Call Should Succeed     Uart Init
     PHILIP.Setup Uart
+    API Call Should Succeed     Uart Init
     DUT Should Match String     1  ${LONG_TEST_STRING}  ${LONG_TEST_STRING}
     Show PHILIP Statistics
 
 Extended Echo
-    API Call Should Succeed     Uart Init
     PHILIP.Setup Uart           mode=1
+    API Call Should Succeed     Uart Init
     DUT Should Match String     1  ${SHORT_TEST_STRING}  ${SHORT_TEST_STRING_INC}
     Show PHILIP Statistics
 
 Extended Long Echo
-    API Call Should Succeed     Uart Init
     PHILIP.Setup Uart           mode=1
+    API Call Should Succeed     Uart Init
     DUT Should Match String     1  ${LONG_TEST_STRING}  ${LONG_TEST_STRING_INC}
     Show PHILIP Statistics
 
 Register Access
-    API Call Should Succeed     Uart Init
     PHILIP.Setup Uart           mode=2
+    API Call Should Succeed     Uart Init
     API Call Should Succeed     Uart Send String   ${REG_USER_READ}
     Should Be Equal             ${RESULT['data']}  ${REG_USER_READ_DATA}
     Show PHILIP Statistics
 
 Should Not Access Invalid Register
-    API Call Should Succeed     Uart Init
     PHILIP.Setup Uart           mode=2
+    API Call Should Succeed     Uart Init
     API Call Should Succeed     Uart Send String      ${REG_WRONG_READ}
     Should Be Equal             ${RESULT['data']}     ${REG_WRONG_READ_DATA}
     Show PHILIP Statistics
 
 Baud Test 38400
-    API Call Should Succeed     Uart Init             baud=${38400}
     PHILIP.Setup Uart           baudrate=38400
+    API Call Should Succeed     Uart Init             baud=${38400}
     DUT Should Match String     1  ${SHORT_TEST_STRING}  ${SHORT_TEST_STRING}
     Show PHILIP Statistics
 
 Baud Test 9600
-    API Call Should Succeed     Uart Init             baud=${9600}
     PHILIP.Setup Uart           baudrate=9600
+    API Call Should Succeed     Uart Init             baud=${9600}
     DUT Should Match String     1  ${SHORT_TEST_STRING}  ${SHORT_TEST_STRING}
     Show PHILIP Statistics
 
 Wrong Baud Test
-    API Call Should Succeed     Uart Init             baud=${38400}
     PHILIP.Setup Uart
+    API Call Should Succeed     Uart Init             baud=${38400}
     DUT Should Not Match String or Timeout   1  ${SHORT_TEST_STRING}  ${SHORT_TEST_STRING}
     Show PHILIP Statistics

--- a/tests/periph_uart/tests/periph_uart_if.py
+++ b/tests/periph_uart/tests/periph_uart_if.py
@@ -17,7 +17,10 @@ class PeriphUartIf(DutShell):
 
     def uart_init(self, dev=DEFAULT_DEV, baud=DEFAULT_BAUD):
         """Initialize DUT's UART."""
-        return self.send_cmd("init {} {}".format(dev, baud))
+        ret = self.send_cmd("init {} {}".format(dev, baud))
+        # Clear buffer from init by sending and receiving
+        self.send_cmd("send {} {}".format(dev, "flush"))
+        return ret
 
     def uart_mode(self, data_bits, parity, stop_bits, dev=DEFAULT_DEV):
         """Setup databits, parity and stopbits."""


### PR DESCRIPTION
This commit switches philip initialization to the start which prevents philip init from providing unwanted bytes to the dut. It also clears the dut buffer by discarding a junk message.
This greatly improves reliability.

Run through tests with master and with this PR (on the samr21 or nucleo-l073) a few times to ensure initial byte errors are corrected.