### PR TITLE
tests/uart: Fix failing uart mode tests

### DIFF
--- a/tests/periph_uart/tests/01__periph_uart_base.robot
+++ b/tests/periph_uart/tests/01__periph_uart_base.robot
@@ -1,11 +1,12 @@
 *** Settings ***
 Documentation       Verify basic functionality of the periph UART API.
 
-Suite Setup         Run Keywords    RIOT Reset
-...                                 PHILIP Reset
+Suite Setup         Run Keywords    PHILIP Reset
+...                                 RIOT Reset
 ...                                 API Firmware Should Match
-Test Setup          Run Keywords    RIOT Reset
-...                                 PHILIP Reset
+Test Setup          Run Keywords    PHILIP Reset
+...                                 RIOT Reset
+...                                 API Firmware Should Match
 
 Resource            periph_uart.keywords.txt
 Resource            api_shell.keywords.txt

--- a/tests/periph_uart/tests/01__periph_uart_base.robot
+++ b/tests/periph_uart/tests/01__periph_uart_base.robot
@@ -6,7 +6,6 @@ Suite Setup         Run Keywords    PHILIP Reset
 ...                                 API Firmware Should Match
 Test Setup          Run Keywords    PHILIP Reset
 ...                                 RIOT Reset
-...                                 API Firmware Should Match
 
 Resource            periph_uart.keywords.txt
 Resource            api_shell.keywords.txt

--- a/tests/periph_uart/tests/01__periph_uart_base.robot
+++ b/tests/periph_uart/tests/01__periph_uart_base.robot
@@ -17,56 +17,56 @@ Force Tags          periph  uart
 *** Test Cases ***
 Echo
     PHILIP.Setup Uart
-    API Call Should Succeed     Uart Init
-    DUT Should Match String     1  ${SHORT_TEST_STRING}  ${SHORT_TEST_STRING}
+    DUT Uart Init and Flush Should Succeed
+    DUT Should Match String                 ${SHORT_TEST_STRING}  ${SHORT_TEST_STRING}
     Show PHILIP Statistics
 
 Long Echo
     PHILIP.Setup Uart
-    API Call Should Succeed     Uart Init
-    DUT Should Match String     1  ${LONG_TEST_STRING}  ${LONG_TEST_STRING}
+    DUT Uart Init and Flush Should Succeed
+    DUT Should Match String                 ${LONG_TEST_STRING}  ${LONG_TEST_STRING}
     Show PHILIP Statistics
 
 Extended Echo
-    PHILIP.Setup Uart           mode=1
-    API Call Should Succeed     Uart Init
-    DUT Should Match String     1  ${SHORT_TEST_STRING}  ${SHORT_TEST_STRING_INC}
+    PHILIP.Setup Uart                       mode=1
+    DUT Uart Init and Flush Should Succeed
+    DUT Should Match String                 ${SHORT_TEST_STRING}  ${SHORT_TEST_STRING_INC}
     Show PHILIP Statistics
 
 Extended Long Echo
-    PHILIP.Setup Uart           mode=1
-    API Call Should Succeed     Uart Init
-    DUT Should Match String     1  ${LONG_TEST_STRING}  ${LONG_TEST_STRING_INC}
+    PHILIP.Setup Uart                       mode=1
+    DUT Uart Init and Flush Should Succeed
+    DUT Should Match String                 ${LONG_TEST_STRING}  ${LONG_TEST_STRING_INC}
     Show PHILIP Statistics
 
 Register Access
-    PHILIP.Setup Uart           mode=2
-    API Call Should Succeed     Uart Init
-    API Call Should Succeed     Uart Send String   ${REG_USER_READ}
-    Should Be Equal             ${RESULT['data']}  ${REG_USER_READ_DATA}
+    PHILIP.Setup Uart                       mode=2
+    DUT Uart Init and Flush Should Succeed
+    API Call Should Succeed                 Uart Send String    ${REG_USER_READ}
+    Should Be Equal                         ${RESULT['data']}   ${REG_USER_READ_DATA}
     Show PHILIP Statistics
 
 Should Not Access Invalid Register
-    PHILIP.Setup Uart           mode=2
-    API Call Should Succeed     Uart Init
-    API Call Should Succeed     Uart Send String      ${REG_WRONG_READ}
-    Should Be Equal             ${RESULT['data']}     ${REG_WRONG_READ_DATA}
+    PHILIP.Setup Uart                       mode=2
+    DUT Uart Init and Flush Should Succeed
+    API Call Should Succeed                 Uart Send String      ${REG_WRONG_READ}
+    Should Be Equal                         ${RESULT['data']}     ${REG_WRONG_READ_DATA}
     Show PHILIP Statistics
 
 Baud Test 38400
-    PHILIP.Setup Uart           baudrate=38400
-    API Call Should Succeed     Uart Init             baud=${38400}
-    DUT Should Match String     1  ${SHORT_TEST_STRING}  ${SHORT_TEST_STRING}
+    PHILIP.Setup Uart                       baudrate=38400
+    DUT Uart Init and Flush Should Succeed  baud=${38400}
+    DUT Should Match String                 ${SHORT_TEST_STRING}  ${SHORT_TEST_STRING}
     Show PHILIP Statistics
 
 Baud Test 9600
-    PHILIP.Setup Uart           baudrate=9600
-    API Call Should Succeed     Uart Init             baud=${9600}
-    DUT Should Match String     1  ${SHORT_TEST_STRING}  ${SHORT_TEST_STRING}
+    PHILIP.Setup Uart                       baudrate=9600
+    DUT Uart Init and Flush Should Succeed  baud=${9600}
+    DUT Should Match String                 ${SHORT_TEST_STRING}  ${SHORT_TEST_STRING}
     Show PHILIP Statistics
 
 Wrong Baud Test
     PHILIP.Setup Uart
-    API Call Should Succeed     Uart Init             baud=${38400}
-    DUT Should Not Match String or Timeout   1  ${SHORT_TEST_STRING}  ${SHORT_TEST_STRING}
+    DUT Uart Init and Flush Should Succeed  baud=${38400}
+    DUT Should Not Match String or Timeout  ${SHORT_TEST_STRING}  ${SHORT_TEST_STRING}
     Show PHILIP Statistics

--- a/tests/periph_uart/tests/02__periph_uart_mode.robot
+++ b/tests/periph_uart/tests/02__periph_uart_mode.robot
@@ -16,46 +16,46 @@ Force Tags          periph  uart
 
 *** Test Cases ***
 Even Parity 8 Bits
-    DUT UART mode should exist  dev=1
-    PHILIP.Setup Uart           parity=${UART_PARITY_EVEN}
-    API Call Should Succeed     Uart Mode             data_bits=8   parity="E"   stop_bits=1
-    DUT Should Match String     1  ${SHORT_TEST_STRING}  ${SHORT_TEST_STRING}
-    API Call Should Succeed     Uart Mode             data_bits=8   parity="O"   stop_bits=1
-    DUT Should Not Match String or Timeout     1   ${SHORT_TEST_STRING}   ${SHORT_TEST_STRING}
+    DUT UART mode should exist
+    PHILIP.Setup Uart                       parity=${UART_PARITY_EVEN}
+    DUT Uart Mode Change Should Succeed     data_bits=8  parity="E"  stop_bits=1
+    DUT Should Match String                 ${SHORT_TEST_STRING}  ${SHORT_TEST_STRING}
+    DUT Uart Mode Change Should Succeed     data_bits=8   parity="O"   stop_bits=1
+    DUT Should Not Match String or Timeout  ${SHORT_TEST_STRING}   ${SHORT_TEST_STRING}
     Show PHILIP Statistics
 
 Odd Parity 8 Bits
-    DUT UART mode should exist  dev=1
-    PHILIP.Setup Uart           parity=${UART_PARITY_ODD}
-    API Call Should Succeed     Uart Mode             data_bits=8   parity="O"   stop_bits=1
-    DUT Should Match String     1  ${SHORT_TEST_STRING}  ${SHORT_TEST_STRING}
-    API Call Should Succeed     Uart Mode             data_bits=8   parity="E"   stop_bits=1
-    DUT Should Not Match String or Timeout     1   ${SHORT_TEST_STRING}   ${SHORT_TEST_STRING}
+    DUT UART mode should exist
+    PHILIP.Setup Uart                       parity=${UART_PARITY_ODD}
+    DUT Uart Mode Change Should Succeed     data_bits=8   parity="O"   stop_bits=1
+    DUT Should Match String                 ${SHORT_TEST_STRING}  ${SHORT_TEST_STRING}
+    DUT Uart Mode Change Should Succeed     data_bits=8   parity="E"   stop_bits=1
+    DUT Should Not Match String or Timeout  ${SHORT_TEST_STRING}   ${SHORT_TEST_STRING}
     Show PHILIP Statistics
 
 Even Parity 7 Bits
-    DUT UART mode should exist  dev=1
-    PHILIP.Setup Uart           parity=${UART_PARITY_EVEN}   databits=${UART_DATA_BITS_7}
-    API Call Should Succeed     Uart Mode             data_bits=7   parity="E"   stop_bits=1
-    DUT Should Match String     1  ${SHORT_TEST_STRING}  ${SHORT_TEST_STRING}
-    API Call Should Succeed     Uart Mode             data_bits=7   parity="O"   stop_bits=1
-    DUT Should Not Match String or Timeout     1   ${SHORT_TEST_STRING}   ${SHORT_TEST_STRING}
+    DUT UART mode should exist
+    PHILIP.Setup Uart                       parity=${UART_PARITY_EVEN}   databits=${UART_DATA_BITS_7}
+    DUT Uart Mode Change Should Succeed     data_bits=7   parity="E"   stop_bits=1
+    DUT Should Match String                 ${SHORT_TEST_STRING}  ${SHORT_TEST_STRING}
+    DUT Uart Mode Change Should Succeed     data_bits=7   parity="O"   stop_bits=1
+    DUT Should Not Match String or Timeout  ${SHORT_TEST_STRING}   ${SHORT_TEST_STRING}
     Show PHILIP Statistics
 
 Odd Parity 7 Bits
-    DUT UART mode should exist  dev=1
-    PHILIP.Setup Uart           parity=${UART_PARITY_ODD}   databits=${UART_DATA_BITS_7}
-    API Call Should Succeed     Uart Mode             data_bits=7   parity="O"   stop_bits=1
-    DUT Should Match String     1  ${SHORT_TEST_STRING}  ${SHORT_TEST_STRING}
-    API Call Should Succeed     Uart Mode             data_bits=7   parity="E"   stop_bits=1
-    DUT Should Not Match String or Timeout     1   ${SHORT_TEST_STRING}   ${SHORT_TEST_STRING}
+    DUT UART mode should exist
+    PHILIP.Setup Uart                       parity=${UART_PARITY_ODD}   databits=${UART_DATA_BITS_7}
+    DUT Uart Mode Change Should Succeed     data_bits=7   parity="O"   stop_bits=1
+    DUT Should Match String                 ${SHORT_TEST_STRING}  ${SHORT_TEST_STRING}
+    DUT Uart Mode Change Should Succeed     data_bits=7   parity="E"   stop_bits=1
+    DUT Should Not Match String or Timeout  ${SHORT_TEST_STRING}   ${SHORT_TEST_STRING}
     Show PHILIP Statistics
 
 Two Stop Bits
-    DUT UART mode should exist  dev=1
-    PHILIP.Setup Uart           parity=${UART_PARITY_ODD}
-    API Call Should Succeed     Uart Mode             data_bits=8   parity="N"   stop_bits=2
-    DUT Should Match String     1  ${TEST_STRING_FOR_STOP_BITS}  ${TEST_STRING_FOR_STOP_BITS}
-    API Call Should Succeed     Uart Mode             data_bits=8   parity="N"   stop_bits=1
-    DUT Should Not Match String or Timeout     1   ${TEST_STRING_FOR_STOP_BITS}   ${TEST_STRING_FOR_STOP_BITS}
+    DUT UART mode should exist
+    PHILIP.Setup Uart                       parity=${UART_PARITY_ODD}
+    DUT Uart Mode Change Should Succeed     data_bits=8   parity="N"   stop_bits=2
+    DUT Should Match String                 ${TEST_STRING_FOR_STOP_BITS}  ${TEST_STRING_FOR_STOP_BITS}
+    DUT Uart Mode Change Should Succeed     data_bits=8   parity="N"   stop_bits=1
+    DUT Should Not Match String or Timeout  ${TEST_STRING_FOR_STOP_BITS}   ${TEST_STRING_FOR_STOP_BITS}
     Show PHILIP Statistics

--- a/tests/periph_uart/tests/02__periph_uart_mode.robot
+++ b/tests/periph_uart/tests/02__periph_uart_mode.robot
@@ -1,11 +1,12 @@
 *** Settings ***
 Documentation       Verify mode config functionality of the periph UART API.
 
-Suite Setup         Run Keywords    RIOT Reset
-...                                 PHILIP Reset
+Suite Setup         Run Keywords    PHILIP Reset
+...                                 RIOT Reset
 ...                                 API Firmware Should Match
-Test Setup          Run Keywords    RIOT Reset
-...                                 PHILIP Reset
+Test Setup          Run Keywords    PHILIP Reset
+...                                 RIOT Reset
+...                                 API Firmware Should Match
 
 Resource            periph_uart.keywords.txt
 Resource            api_shell.keywords.txt
@@ -17,8 +18,7 @@ Force Tags          periph  uart
 *** Test Cases ***
 Even Parity 8 Bits
     DUT UART mode should exist  dev=1
-    PHILIP.Setup Uart		parity=${UART_PARITY_EVEN}
-    API Call Should Succeed     Uart Init
+    PHILIP.Setup Uart           parity=${UART_PARITY_EVEN}
     API Call Should Succeed     Uart Mode             data_bits=8   parity="E"   stop_bits=1
     DUT Should Match String     1  ${SHORT_TEST_STRING}  ${SHORT_TEST_STRING}
     API Call Should Succeed     Uart Mode             data_bits=8   parity="O"   stop_bits=1
@@ -27,8 +27,7 @@ Even Parity 8 Bits
 
 Odd Parity 8 Bits
     DUT UART mode should exist  dev=1
-    PHILIP.Setup Uart		parity=${UART_PARITY_ODD}
-    API Call Should Succeed     Uart Init
+    PHILIP.Setup Uart           parity=${UART_PARITY_ODD}
     API Call Should Succeed     Uart Mode             data_bits=8   parity="O"   stop_bits=1
     DUT Should Match String     1  ${SHORT_TEST_STRING}  ${SHORT_TEST_STRING}
     API Call Should Succeed     Uart Mode             data_bits=8   parity="E"   stop_bits=1
@@ -37,8 +36,7 @@ Odd Parity 8 Bits
 
 Even Parity 7 Bits
     DUT UART mode should exist  dev=1
-    PHILIP.Setup Uart		parity=${UART_PARITY_EVEN}   databits=${UART_DATA_BITS_7}
-    API Call Should Succeed     Uart Init
+    PHILIP.Setup Uart           parity=${UART_PARITY_EVEN}   databits=${UART_DATA_BITS_7}
     API Call Should Succeed     Uart Mode             data_bits=7   parity="E"   stop_bits=1
     DUT Should Match String     1  ${SHORT_TEST_STRING}  ${SHORT_TEST_STRING}
     API Call Should Succeed     Uart Mode             data_bits=7   parity="O"   stop_bits=1
@@ -47,8 +45,7 @@ Even Parity 7 Bits
 
 Odd Parity 7 Bits
     DUT UART mode should exist  dev=1
-    PHILIP.Setup Uart		parity=${UART_PARITY_ODD}   databits=${UART_DATA_BITS_7}
-    API Call Should Succeed     Uart Init
+    PHILIP.Setup Uart           parity=${UART_PARITY_ODD}   databits=${UART_DATA_BITS_7}
     API Call Should Succeed     Uart Mode             data_bits=7   parity="O"   stop_bits=1
     DUT Should Match String     1  ${SHORT_TEST_STRING}  ${SHORT_TEST_STRING}
     API Call Should Succeed     Uart Mode             data_bits=7   parity="E"   stop_bits=1
@@ -57,8 +54,7 @@ Odd Parity 7 Bits
 
 Two Stop Bits
     DUT UART mode should exist  dev=1
-    PHILIP.Setup Uart		parity=${UART_PARITY_ODD}
-    API Call Should Succeed     Uart Init
+    PHILIP.Setup Uart           parity=${UART_PARITY_ODD}
     API Call Should Succeed     Uart Mode             data_bits=8   parity="N"   stop_bits=2
     DUT Should Match String     1  ${TEST_STRING_FOR_STOP_BITS}  ${TEST_STRING_FOR_STOP_BITS}
     API Call Should Succeed     Uart Mode             data_bits=8   parity="N"   stop_bits=1

--- a/tests/periph_uart/tests/02__periph_uart_mode.robot
+++ b/tests/periph_uart/tests/02__periph_uart_mode.robot
@@ -6,7 +6,6 @@ Suite Setup         Run Keywords    PHILIP Reset
 ...                                 API Firmware Should Match
 Test Setup          Run Keywords    PHILIP Reset
 ...                                 RIOT Reset
-...                                 API Firmware Should Match
 
 Resource            periph_uart.keywords.txt
 Resource            api_shell.keywords.txt

--- a/tests/periph_uart/tests/periph_uart.keywords.txt
+++ b/tests/periph_uart/tests/periph_uart.keywords.txt
@@ -1,5 +1,5 @@
 *** Settings ***
-Library             UartDevice  port=%{PORT}  baudrate=%{BAUD}  timeout=${10}
+Library             UartDevice  port=%{PORT}  baudrate=%{BAUD}  timeout=${0.5}
 Library             periph_uart_if.PeriphUartUtil
 
 Resource            api_shell.keywords.txt
@@ -7,21 +7,31 @@ Resource            philip.keywords.txt
 
 *** Keywords ***
 DUT Should Match String
-    [Arguments]                 ${dev}  ${test_string}  ${reference_string}
-    ${RESULT}=                  Run Keyword  Uart Send String   dev=${dev}  test_string=${test_string}
+    [Arguments]                 ${test_string}  ${reference_string}
+    ${RESULT}=                  Run Keyword  Uart Send String   test_string=${test_string}
     ${stat}=                    Get PHILIP Statistics
-    ${err_msg}=                 Message for should match   ${RESULT}   ${reference_string}   ${stat}
+    ${err_msg}=                 Message for should match        ${RESULT}   ${reference_string}   ${stat}
     Should Be Empty             ${err_msg}   ${err_msg}
 
 DUT Should Not Match String or Timeout
-    [Arguments]                 ${dev}  ${test_string}  ${reference_string}
-    ${RESULT}=                  Run Keyword  Uart Send String   dev=${dev}  test_string=${test_string}
+    [Arguments]                 ${test_string}  ${reference_string}
+    ${RESULT}=                  Run Keyword  Uart Send String   test_string=${test_string}
     ${stat}=                    Get PHILIP Statistics
-    ${err_msg}=                 Message for should not match   ${RESULT}   ${reference_string}   ${stat}
+    ${err_msg}=                 Message for should not match    ${RESULT}   ${reference_string}   ${stat}
     #Should Be True              '${RESULT['result']}'=='Timeout' or '${rcv_string}'!='${reference_string}'   msg=${stat}
     Should Be Empty             ${err_msg}   ${err_msg}
 
 DUT UART mode should exist
-    [Arguments]                 ${dev}
-    ${status}   ${value}=       Run Keyword And Ignore Error   API Call Should Succeed   Uart Mode   dev=${dev}   data_bits=8   parity="N"   stop_bits=1
+    ${status}   ${value}=       Run Keyword And Ignore Error   API Call Should Succeed   Uart Mode   data_bits=8   parity="N"   stop_bits=1
     Pass Execution If           '${status}'=='FAIL'   Feature is not supported
+
+DUT Uart Mode Change Should Succeed
+    [Arguments]                 @{args}  &{kwargs}
+    API Call Should Succeed     Uart Init
+    API Call Should Succeed     Uart Mode   @{args}  &{kwargs}
+    Uart Send string            flush
+
+DUT Uart Init and Flush Should Succeed
+    [Arguments]                 @{args}  &{kwargs}
+    API Call Should Succeed     Uart Init   @{args}  &{kwargs}
+    Uart Send string            flush

--- a/tests/periph_uart/tests/periph_uart.keywords.txt
+++ b/tests/periph_uart/tests/periph_uart.keywords.txt
@@ -22,7 +22,7 @@ DUT Should Not Match String or Timeout
     Should Be Empty             ${err_msg}   ${err_msg}
 
 DUT UART mode should exist
-    ${status}   ${value}=       Run Keyword And Ignore Error   API Call Should Succeed   Uart Mode   data_bits=8   parity="N"   stop_bits=1
+    ${status}   ${value}=       Run Keyword And Ignore Error   API Call Should Succeed   Uart Mode
     Pass Execution If           '${status}'=='FAIL'   Feature is not supported
 
 DUT Uart Mode Change Should Succeed

--- a/tests/periph_uart/tests/periph_uart_if.py
+++ b/tests/periph_uart/tests/periph_uart_if.py
@@ -22,10 +22,15 @@ class PeriphUartIf(DutShell):
         self.send_cmd("send {} {}".format(dev, "flush"))
         return ret
 
-    def uart_mode(self, data_bits, parity, stop_bits, dev=DEFAULT_DEV):
+    def uart_mode(self, data_bits, parity, stop_bits, dev=DEFAULT_DEV,
+                  baud=DEFAULT_BAUD):
         """Setup databits, parity and stopbits."""
-        return self.send_cmd(
+        self.send_cmd("init {} {}".format(dev, baud))
+        ret = self.send_cmd(
             "mode {} {} {} {}".format(dev, data_bits, parity, stop_bits))
+
+        self.send_cmd("send {} {}".format(dev, "flush\n"))
+        return ret
 
     def uart_send_string(self, test_string, dev=DEFAULT_DEV):
         """Send data via DUT's UART."""

--- a/tests/periph_uart/tests/periph_uart_if.py
+++ b/tests/periph_uart/tests/periph_uart_if.py
@@ -18,19 +18,12 @@ class PeriphUartIf(DutShell):
     def uart_init(self, dev=DEFAULT_DEV, baud=DEFAULT_BAUD):
         """Initialize DUT's UART."""
         ret = self.send_cmd("init {} {}".format(dev, baud))
-        # Clear buffer from init by sending and receiving
-        self.uart_send_string("flush", dev)
         return ret
 
-    def uart_mode(self, data_bits, parity, stop_bits, dev=DEFAULT_DEV,
-                  baud=DEFAULT_BAUD):
+    def uart_mode(self, data_bits, parity, stop_bits, dev=DEFAULT_DEV):
         """Setup databits, parity and stopbits."""
-        # Init should be called before a mode change
-        self.send_cmd("init {} {}".format(dev, baud))
         ret = self.send_cmd(
             "mode {} {} {} {}".format(dev, data_bits, parity, stop_bits))
-        # Clear buffer only after mode setting
-        self.uart_send_string("flush", dev)
         return ret
 
     def uart_send_string(self, test_string, dev=DEFAULT_DEV):

--- a/tests/periph_uart/tests/periph_uart_if.py
+++ b/tests/periph_uart/tests/periph_uart_if.py
@@ -17,14 +17,12 @@ class PeriphUartIf(DutShell):
 
     def uart_init(self, dev=DEFAULT_DEV, baud=DEFAULT_BAUD):
         """Initialize DUT's UART."""
-        ret = self.send_cmd("init {} {}".format(dev, baud))
-        return ret
+        return self.send_cmd("init {} {}".format(dev, baud))
 
     def uart_mode(self, data_bits, parity, stop_bits, dev=DEFAULT_DEV):
         """Setup databits, parity and stopbits."""
-        ret = self.send_cmd(
-            "mode {} {} {} {}".format(dev, data_bits, parity, stop_bits))
-        return ret
+        return self.send_cmd("mode {} {} {} {}".format(dev, data_bits, parity,
+                                                       stop_bits))
 
     def uart_send_string(self, test_string, dev=DEFAULT_DEV):
         """Send data via DUT's UART."""

--- a/tests/periph_uart/tests/periph_uart_if.py
+++ b/tests/periph_uart/tests/periph_uart_if.py
@@ -19,7 +19,7 @@ class PeriphUartIf(DutShell):
         """Initialize DUT's UART."""
         return self.send_cmd("init {} {}".format(dev, baud))
 
-    def uart_mode(self, data_bits, parity, stop_bits, dev=DEFAULT_DEV):
+    def uart_mode(self, data_bits=8, parity="N", stop_bits=1, dev=DEFAULT_DEV):
         """Setup databits, parity and stopbits."""
         return self.send_cmd("mode {} {} {} {}".format(dev, data_bits, parity,
                                                        stop_bits))

--- a/tests/periph_uart/tests/periph_uart_if.py
+++ b/tests/periph_uart/tests/periph_uart_if.py
@@ -19,17 +19,18 @@ class PeriphUartIf(DutShell):
         """Initialize DUT's UART."""
         ret = self.send_cmd("init {} {}".format(dev, baud))
         # Clear buffer from init by sending and receiving
-        self.send_cmd("send {} {}".format(dev, "flush"))
+        self.uart_send_string("flush", dev)
         return ret
 
     def uart_mode(self, data_bits, parity, stop_bits, dev=DEFAULT_DEV,
                   baud=DEFAULT_BAUD):
         """Setup databits, parity and stopbits."""
+        # Init should be called before a mode change
         self.send_cmd("init {} {}".format(dev, baud))
         ret = self.send_cmd(
             "mode {} {} {} {}".format(dev, data_bits, parity, stop_bits))
-
-        self.send_cmd("send {} {}".format(dev, "flush\n"))
+        # Clear buffer only after mode setting
+        self.uart_send_string("flush", dev)
         return ret
 
     def uart_send_string(self, test_string, dev=DEFAULT_DEV):


### PR DESCRIPTION
After reset was updated philip was not being reset after mode change
This commit fixes and helps flush the mode..
Since philip spits out data on reset it also is reset first.

Test on boards that support uart mode.