### PR TITLE
tests/periph_uart: full rework

### DIFF
--- a/dist/robotframework/res/api_shell.keywords.txt
+++ b/dist/robotframework/res/api_shell.keywords.txt
@@ -31,15 +31,25 @@ API Get Last Result As Integer
     ${ret}=             Convert to Integer  ${RESULT['data'][0]}
     [Return]            ${ret}
 
-API Last Result Message Should Contain
+API Result Message Should Contain
     [Documentation]     Fails if ${msg} is not in the last API message
     [Arguments]         ${msg}
     Should Contain      ${RESULT['msg']}  ${msg}
 
+API Result Data Should Contain
+    [Documentation]     Fails if ${data} is not in the last API Result
+    [Arguments]         ${data}
+    Should Contain Match  ${RESULT['data']}  ${data}
+
+API Result Data Should Not Contain
+    [Documentation]     Fails if ${data} is in the last API Result
+    [Arguments]         ${data}
+    Should Not Contain Match  ${RESULT['data']}  ${data}
+
 API Call Repeat on Timeout
     [Documentation]     Repeats the given API ``call`` up to 5 times on timeout.
     [Arguments]         ${call}  @{args}  &{kwargs}
-    :FOR    ${i}    IN RANGE  0  5
+    :FOR    ${i}    IN RANGE  0  16
     \   Run Keyword And Ignore Error  API Call Should Timeout  ${call}  @{args}  &{kwargs}
     \   Run Keyword If  "${RESULT['result']}"!="Timeout"  Exit For Loop
     Should Contain      ${RESULT['result']}   Success
@@ -49,3 +59,8 @@ API Firmware Should Match
     [Arguments]         ${firmware}=%{APPLICATION}
     API Call Repeat on Timeout  Get Metadata
     Should Contain      ${RESULT['msg']}  ${firmware}
+
+API Sync Shell
+    [Documentation]     Verify that the DUT runs the required API test firmware
+    [Arguments]         ${firmware}=%{APPLICATION}
+    API Call Repeat on Timeout  Get Metadata

--- a/tests/periph_i2c/tests/01__periph_i2c_base.robot
+++ b/tests/periph_i2c/tests/01__periph_i2c_base.robot
@@ -1,11 +1,12 @@
 *** Settings ***
 Documentation       Verify basic functionality of the periph I2C API.
 
-Suite Setup         Run Keywords    RIOT Reset
-...                                 PHILIP Reset
+Suite Setup         Run Keywords    PHILIP Reset
+...                                 RIOT Reset
 ...                                 API Firmware Should Match
-Test Setup          Run Keywords    RIOT Reset
-...                                 PHILIP Reset
+Test Setup          Run Keywords    PHILIP Reset
+...                                 RIOT Reset
+...                                 API Sync Shell
 
 Resource            periph_i2c.keywords.txt
 Resource            api_shell.keywords.txt

--- a/tests/periph_i2c/tests/02__periph_i2c_write_register.robot
+++ b/tests/periph_i2c/tests/02__periph_i2c_write_register.robot
@@ -1,11 +1,12 @@
 *** Settings ***
 Documentation       Data driven tests to verify the i2c_write_regs call.
 
-Suite Setup         Run Keywords    RIOT Reset
-...                                 PHILIP Reset
+Suite Setup         Run Keywords    PHILIP Reset
+...                                 RIOT Reset
 ...                                 API Firmware Should Match
-Test Setup          Run Keywords    RIOT Reset
-...                                 PHILIP Reset
+Test Setup          Run Keywords    PHILIP Reset
+...                                 RIOT Reset
+...                                 API Sync Shell
 ...                                 I2C Acquire
 Test Teardown       I2C Release
 Test Template       I2C Write Bytes To Register Should Succeed

--- a/tests/periph_i2c/tests/03__periph_i2c_error_codes.robot
+++ b/tests/periph_i2c/tests/03__periph_i2c_error_codes.robot
@@ -1,16 +1,18 @@
 *** Settings ***
 Documentation       Tests to verify correct error codes are given.
 
-Suite Setup         Run Keywords    RIOT Reset
-...                                 PHILIP Reset
+Suite Setup         Run Keywords    PHILIP Reset
+...                                 RIOT Reset
 ...                                 API Firmware Should Match
-Test Setup          Run Keywords    RIOT Reset
-...                                 PHILIP Reset
+Test Setup          Run Keywords    PHILIP Reset
+...                                 RIOT Reset
+...                                 API Sync Shell
 ...                                 I2C Acquire
 Test Teardown       I2C Release
 
 Resource            periph_i2c.keywords.txt
 Resource            api_shell.keywords.txt
+Resource            riot_base.keywords.txt
 
 Force Tags          periph  i2c
 
@@ -18,10 +20,10 @@ Force Tags          periph  i2c
 Invalid Address Should Fail With Address NACK
     [Documentation]                         Verify address NACK (ENXIO) occurs
     API Call Should Error                   I2C Read Reg  addr=42
-    API Last Result Message Should Contain  ENXIO
+    API Result Message Should Contain       ENXIO
 
 Invalid Data Should Fail With Data NACK
     [Documentation]                         Verify data NACK (EIO) occurs
     PHiLIP.write and execute                i2c.mode.nack_data  1
     API Call Should Error                   I2C Read Reg
-    API Last Result Message Should Contain  EIO
+    API Result Message Should Contain       EIO

--- a/tests/periph_uart/main.c
+++ b/tests/periph_uart/main.c
@@ -128,7 +128,7 @@ static void sleep_test(int num, uart_t uart)
     puts("[OK]");
 }
 
-static int cmd_init(int argc, char **argv)
+static int cmd_uart_init(int argc, char **argv)
 {
     int dev, res;
     uint32_t baud;
@@ -164,7 +164,7 @@ static int cmd_init(int argc, char **argv)
 }
 
 #ifdef MODULE_PERIPH_UART_MODECFG
-static int cmd_mode(int argc, char **argv)
+static int cmd_uart_mode(int argc, char **argv)
 {
     int dev, data_bits_arg, stop_bits_arg;
     uart_data_bits_t data_bits;
@@ -231,7 +231,7 @@ static int cmd_mode(int argc, char **argv)
 }
 #endif /* MODULE_PERIPH_UART_MODECFG */
 
-static int cmd_send(int argc, char **argv)
+static int cmd_uart_write(int argc, char **argv)
 {
     int dev;
     uint8_t endline = (uint8_t)'\n';
@@ -263,11 +263,11 @@ int cmd_get_metadata(int argc, char **argv)
 }
 
 static const shell_command_t shell_commands[] = {
-    { "init", "Initialize a UART device with a given baudrate", cmd_init },
+    { "uart_init", "Initialize a UART device with a given baudrate", cmd_uart_init },
 #ifdef MODULE_PERIPH_UART_MODECFG
-    { "mode", "Setup data bits, stop bits and parity for a given UART device", cmd_mode },
+    { "uart_mode", "Setup data bits, stop bits and parity for a given UART device", cmd_uart_mode },
 #endif
-    { "send", "Send a string through given UART device", cmd_send },
+    { "uart_write", "Send a buffer through given UART device", cmd_uart_write },
     { "get_metadata", "Get the metadata of the test firmware", cmd_get_metadata },
     { NULL, NULL, NULL }
 };

--- a/tests/periph_uart/tests/01__periph_uart_base.robot
+++ b/tests/periph_uart/tests/01__periph_uart_base.robot
@@ -1,11 +1,12 @@
 *** Settings ***
 Documentation       Verify basic functionality of the periph UART API.
 
-Suite Setup         Run Keywords    RIOT Reset
-...                                 PHILIP Reset
+Suite Setup         Run Keywords    PHILIP Reset
+...                                 RIOT Reset
 ...                                 API Firmware Should Match
-Test Setup          Run Keywords    RIOT Reset
-...                                 PHILIP Reset
+Test Setup          Run Keywords    PHILIP Reset
+...                                 RIOT Reset
+...                                 API Sync Shell
 
 Resource            periph_uart.keywords.txt
 Resource            api_shell.keywords.txt
@@ -17,56 +18,62 @@ Force Tags          periph  uart
 *** Test Cases ***
 Echo
     PHILIP.Setup Uart
-    API Call Should Succeed     Uart Init
-    DUT Should Match String     1  ${SHORT_TEST_STRING}  ${SHORT_TEST_STRING}
+    UART Init and Flush Should Succeed
+    API Call Should Succeed     Uart Write  ${SHORT_TEST_STRING}
+    API Result Data Should Contain  ${SHORT_TEST_STRING}
     Show PHILIP Statistics
 
 Long Echo
     PHILIP.Setup Uart
-    API Call Should Succeed     Uart Init
-    DUT Should Match String     1  ${LONG_TEST_STRING}  ${LONG_TEST_STRING}
+    UART Init and Flush Should Succeed
+    API Call Should Succeed     Uart Write  ${LONG_TEST_STRING}
+    API Result Data Should Contain  ${LONG_TEST_STRING}
     Show PHILIP Statistics
 
 Extended Echo
     PHILIP.Setup Uart           mode=1
-    API Call Should Succeed     Uart Init
-    DUT Should Match String     1  ${SHORT_TEST_STRING}  ${SHORT_TEST_STRING_INC}
+    UART Init and Flush Should Succeed
+    API Call Should Succeed     Uart Write  ${SHORT_TEST_STRING}
+    API Result Data Should Contain  ${SHORT_TEST_STRING_INC}
     Show PHILIP Statistics
 
 Extended Long Echo
     PHILIP.Setup Uart           mode=1
-    API Call Should Succeed     Uart Init
-    DUT Should Match String     1  ${LONG_TEST_STRING}  ${LONG_TEST_STRING_INC}
+    UART Init and Flush Should Succeed
+    API Call Should Succeed     Uart Write  ${LONG_TEST_STRING}
+    API Result Data Should Contain  ${LONG_TEST_STRING_INC}
     Show PHILIP Statistics
 
 Register Access
     PHILIP.Setup Uart           mode=2
-    API Call Should Succeed     Uart Init
-    API Call Should Succeed     Uart Send String   ${REG_USER_READ}
-    Should Be Equal             ${RESULT['data']}  ${REG_USER_READ_DATA}
+    UART Init and Flush Should Succeed
+    API Call Should Succeed     Uart Write          ${REG_USER_READ}
+    Should Be Equal             ${RESULT['data']}   ${REG_USER_READ_DATA}
     Show PHILIP Statistics
 
 Should Not Access Invalid Register
     PHILIP.Setup Uart           mode=2
-    API Call Should Succeed     Uart Init
-    API Call Should Succeed     Uart Send String      ${REG_WRONG_READ}
-    Should Be Equal             ${RESULT['data']}     ${REG_WRONG_READ_DATA}
+    UART Init and Flush Should Succeed
+    API Call Should Succeed     Uart Write          ${REG_WRONG_READ}
+    Should Be Equal             ${RESULT['data']}   ${REG_WRONG_READ_DATA}
     Show PHILIP Statistics
 
 Baud Test 38400
     PHILIP.Setup Uart           baudrate=38400
-    API Call Should Succeed     Uart Init             baud=${38400}
-    DUT Should Match String     1  ${SHORT_TEST_STRING}  ${SHORT_TEST_STRING}
+    UART Init and Flush Should Succeed      baud=${38400}
+    API Call Should Succeed     Uart Write  ${SHORT_TEST_STRING}
+    API Result Data Should Contain  ${SHORT_TEST_STRING}
     Show PHILIP Statistics
 
 Baud Test 9600
     PHILIP.Setup Uart           baudrate=9600
-    API Call Should Succeed     Uart Init             baud=${9600}
-    DUT Should Match String     1  ${SHORT_TEST_STRING}  ${SHORT_TEST_STRING}
+    UART Init and Flush Should Succeed      baud=${9600}
+    API Call Should Succeed     Uart Write  ${SHORT_TEST_STRING}
+    API Result Data Should Contain  ${SHORT_TEST_STRING}
     Show PHILIP Statistics
 
 Wrong Baud Test
-    PHILIP.Setup Uart
-    API Call Should Succeed     Uart Init             baud=${38400}
-    DUT Should Not Match String or Timeout   1  ${SHORT_TEST_STRING}  ${SHORT_TEST_STRING}
+    PHILIP.Setup Uart           baudrate=9600
+    UART Init and Flush Should Succeed      baud=${38400}
+    API Call Should Timeout     Uart Write  ${SHORT_TEST_STRING}
     Show PHILIP Statistics

--- a/tests/periph_uart/tests/02__periph_uart_mode.robot
+++ b/tests/periph_uart/tests/02__periph_uart_mode.robot
@@ -1,11 +1,12 @@
 *** Settings ***
 Documentation       Verify mode config functionality of the periph UART API.
 
-Suite Setup         Run Keywords    RIOT Reset
-...                                 PHILIP Reset
+Suite Setup         Run Keywords    PHILIP Reset
+...                                 RIOT Reset
 ...                                 API Firmware Should Match
-Test Setup          Run Keywords    RIOT Reset
-...                                 PHILIP Reset
+Test Setup          Run Keywords    PHILIP Reset
+...                                 RIOT Reset
+...                                 API Sync Shell
 
 Resource            periph_uart.keywords.txt
 Resource            api_shell.keywords.txt
@@ -16,51 +17,52 @@ Force Tags          periph  uart
 
 *** Test Cases ***
 Even Parity 8 Bits
-    DUT UART mode should exist  dev=1
-    PHILIP.Setup Uart		parity=${UART_PARITY_EVEN}
-    API Call Should Succeed     Uart Init
-    API Call Should Succeed     Uart Mode             data_bits=8   parity="E"   stop_bits=1
-    DUT Should Match String     1  ${SHORT_TEST_STRING}  ${SHORT_TEST_STRING}
-    API Call Should Succeed     Uart Mode             data_bits=8   parity="O"   stop_bits=1
-    DUT Should Not Match String or Timeout     1   ${SHORT_TEST_STRING}   ${SHORT_TEST_STRING}
+    UART Mode Should Exist
+    PHILIP.Setup Uart           parity=${UART_PARITY_EVEN}
+    UART Mode Change Should Succeed         data_bits=8  parity="E"  stop_bits=1
+    API Call Should Succeed     Uart Write  ${SHORT_TEST_STRING}
+    API Result Data Should Contain  ${SHORT_TEST_STRING}
+    UART Mode Change Should Succeed         data_bits=8  parity="O"  stop_bits=1
+    API Call Should Timeout     Uart Write  ${SHORT_TEST_STRING}
     Show PHILIP Statistics
 
 Odd Parity 8 Bits
-    DUT UART mode should exist  dev=1
-    PHILIP.Setup Uart		parity=${UART_PARITY_ODD}
-    API Call Should Succeed     Uart Init
-    API Call Should Succeed     Uart Mode             data_bits=8   parity="O"   stop_bits=1
-    DUT Should Match String     1  ${SHORT_TEST_STRING}  ${SHORT_TEST_STRING}
-    API Call Should Succeed     Uart Mode             data_bits=8   parity="E"   stop_bits=1
-    DUT Should Not Match String or Timeout     1   ${SHORT_TEST_STRING}   ${SHORT_TEST_STRING}
+    UART Mode Should Exist
+    PHILIP.Setup Uart           parity=${UART_PARITY_ODD}
+    UART Mode Change Should Succeed         data_bits=8  parity="O"  stop_bits=1
+    API Call Should Succeed     Uart Write  ${SHORT_TEST_STRING}
+    API Result Data Should Contain  ${SHORT_TEST_STRING}
+    UART Mode Change Should Succeed         data_bits=8  parity="E"  stop_bits=1
+    API Call Should Timeout     Uart Write  ${SHORT_TEST_STRING}
     Show PHILIP Statistics
 
 Even Parity 7 Bits
-    DUT UART mode should exist  dev=1
-    PHILIP.Setup Uart		parity=${UART_PARITY_EVEN}   databits=${UART_DATA_BITS_7}
-    API Call Should Succeed     Uart Init
-    API Call Should Succeed     Uart Mode             data_bits=7   parity="E"   stop_bits=1
-    DUT Should Match String     1  ${SHORT_TEST_STRING}  ${SHORT_TEST_STRING}
-    API Call Should Succeed     Uart Mode             data_bits=7   parity="O"   stop_bits=1
-    DUT Should Not Match String or Timeout     1   ${SHORT_TEST_STRING}   ${SHORT_TEST_STRING}
+    UART Mode Should Exist
+    PHILIP.Setup Uart           parity=${UART_PARITY_EVEN}   databits=${UART_DATA_BITS_7}
+    UART Mode Change Should Succeed         data_bits=7  parity="E"  stop_bits=1
+    API Call Should Succeed     Uart Write  ${SHORT_TEST_STRING}
+    API Result Data Should Contain  ${SHORT_TEST_STRING}
+    UART Mode Change Should Succeed         data_bits=7  parity="O"  stop_bits=1
+    API Call Should Timeout     Uart Write  ${SHORT_TEST_STRING}
     Show PHILIP Statistics
 
 Odd Parity 7 Bits
-    DUT UART mode should exist  dev=1
-    PHILIP.Setup Uart		parity=${UART_PARITY_ODD}   databits=${UART_DATA_BITS_7}
-    API Call Should Succeed     Uart Init
-    API Call Should Succeed     Uart Mode             data_bits=7   parity="O"   stop_bits=1
-    DUT Should Match String     1  ${SHORT_TEST_STRING}  ${SHORT_TEST_STRING}
-    API Call Should Succeed     Uart Mode             data_bits=7   parity="E"   stop_bits=1
-    DUT Should Not Match String or Timeout     1   ${SHORT_TEST_STRING}   ${SHORT_TEST_STRING}
+    UART Mode Should Exist
+    PHILIP.Setup Uart           parity=${UART_PARITY_ODD}   databits=${UART_DATA_BITS_7}
+    UART Mode Change Should Succeed         data_bits=7  parity="O"  stop_bits=1
+    API Call Should Succeed     Uart Write  ${SHORT_TEST_STRING}
+    API Result Data Should Contain  ${SHORT_TEST_STRING}
+    UART Mode Change Should Succeed         data_bits=7  parity="E"  stop_bits=1
+    API Call Should Timeout     Uart Write  ${SHORT_TEST_STRING}
     Show PHILIP Statistics
 
 Two Stop Bits
-    DUT UART mode should exist  dev=1
-    PHILIP.Setup Uart		parity=${UART_PARITY_ODD}
-    API Call Should Succeed     Uart Init
-    API Call Should Succeed     Uart Mode             data_bits=8   parity="N"   stop_bits=2
-    DUT Should Match String     1  ${TEST_STRING_FOR_STOP_BITS}  ${TEST_STRING_FOR_STOP_BITS}
-    API Call Should Succeed     Uart Mode             data_bits=8   parity="N"   stop_bits=1
-    DUT Should Not Match String or Timeout     1   ${TEST_STRING_FOR_STOP_BITS}   ${TEST_STRING_FOR_STOP_BITS}
+    UART Mode Should Exist
+    PHILIP.Setup Uart           parity=${UART_PARITY_ODD}
+    UART Mode Change Should Succeed         data_bits=8  parity="N"  stop_bits=2
+    API Call Should Succeed     Uart Write  ${TEST_STRING_FOR_STOP_BITS}
+    API Result Data Should Contain  ${TEST_STRING_FOR_STOP_BITS}
+    UART Mode Change Should Succeed         data_bits=8  parity="N"  stop_bits=1
+    API Call Should Succeed     Uart Write  ${TEST_STRING_FOR_STOP_BITS}
+    API Result Data Should Not Contain  ${TEST_STRING_FOR_STOP_BITS}
     Show PHILIP Statistics

--- a/tests/periph_uart/tests/periph_uart.keywords.txt
+++ b/tests/periph_uart/tests/periph_uart.keywords.txt
@@ -1,27 +1,29 @@
 *** Settings ***
 Library             UartDevice  port=%{PORT}  baudrate=%{BAUD}  timeout=${10}
-Library             periph_uart_if.PeriphUartUtil
 
 Resource            api_shell.keywords.txt
 Resource            philip.keywords.txt
+Resource            riot_base.keywords.txt
 
 *** Keywords ***
-DUT Should Match String
-    [Arguments]                 ${dev}  ${test_string}  ${reference_string}
-    ${RESULT}=                  Run Keyword  Uart Send String   dev=${dev}  test_string=${test_string}
-    ${stat}=                    Get PHILIP Statistics
-    ${err_msg}=                 Message for should match   ${RESULT}   ${reference_string}   ${stat}
-    Should Be Empty             ${err_msg}   ${err_msg}
+UART Flush
+    [Documentation]             Remove garbage from UART buffer
+    UART write  flush
 
-DUT Should Not Match String or Timeout
-    [Arguments]                 ${dev}  ${test_string}  ${reference_string}
-    ${RESULT}=                  Run Keyword  Uart Send String   dev=${dev}  test_string=${test_string}
-    ${stat}=                    Get PHILIP Statistics
-    ${err_msg}=                 Message for should not match   ${RESULT}   ${reference_string}   ${stat}
-    #Should Be True              '${RESULT['result']}'=='Timeout' or '${rcv_string}'!='${reference_string}'   msg=${stat}
-    Should Be Empty             ${err_msg}   ${err_msg}
+UART Init and Flush Should Succeed
+    [Documentation]             Init UART device and flush buffer
+    [Arguments]                 @{args}  &{kwargs}
+    API Call Should Succeed     Uart Init   @{args}  &{kwargs}
+    UART Flush
 
-DUT UART mode should exist
-    [Arguments]                 ${dev}
-    ${status}   ${value}=       Run Keyword And Ignore Error   API Call Should Succeed   Uart Mode   dev=${dev}   data_bits=8   parity="N"   stop_bits=1
+UART Mode Change Should Succeed
+    [Documentation]             Configure UART mode and flush
+    [Arguments]                 @{args}  &{kwargs}
+    API Call Should Succeed     Uart Init
+    API Call Should Succeed     Uart Mode   @{args}  &{kwargs}
+    UART Flush
+
+UART Mode Should Exist
+    [Documentation]             Verify DUT supports UART mode configuration
+    ${status}   ${value}=       Run Keyword And Ignore Error   API Call Should Succeed   Uart Mode
     Pass Execution If           '${status}'=='FAIL'   Feature is not supported

--- a/tests/periph_uart/tests/periph_uart_if.py
+++ b/tests/periph_uart/tests/periph_uart_if.py
@@ -14,61 +14,26 @@ class PeriphUartIf(DutShell):
     FW_ID = 'periph_uart'
     DEFAULT_DEV = 1
     DEFAULT_BAUD = 115200
+    DEFAULT_PARITY = 'N'
+    DEFAULT_DATA_BITS = 8
+    DEFAULT_STOP_BITS = 1
 
     def uart_init(self, dev=DEFAULT_DEV, baud=DEFAULT_BAUD):
-        """Initialize DUT's UART."""
-        ret = self.send_cmd("init {} {}".format(dev, baud))
+        """Init UART device"""
+        ret = self.send_cmd("uart_init {} {}".format(dev, baud))
         # Clear buffer from init by sending and receiving
-        self.send_cmd("send {} {}".format(dev, "flush"))
+        self.send_cmd("uart_write {} {}".format(dev, "flush"))
         return ret
 
-    def uart_mode(self, data_bits, parity, stop_bits, dev=DEFAULT_DEV):
+    def uart_mode(self, data_bits=DEFAULT_DATA_BITS, parity=DEFAULT_PARITY, stop_bits=DEFAULT_STOP_BITS, dev=DEFAULT_DEV):
         """Setup databits, parity and stopbits."""
         return self.send_cmd(
-            "mode {} {} {} {}".format(dev, data_bits, parity, stop_bits))
+            "uart_mode {} {} {} {}".format(dev, data_bits, parity, stop_bits))
 
-    def uart_send_string(self, test_string, dev=DEFAULT_DEV):
-        """Send data via DUT's UART."""
-        return self.send_cmd("send {} {}".format(dev, test_string))
+    def uart_write(self, data, dev=DEFAULT_DEV):
+        """Write data to UART device."""
+        return self.send_cmd("uart_write {} {}".format(dev, data))
 
     def get_metadata(self):
         """Get the metadata of the firmware."""
         return self.send_cmd('get_metadata')
-
-
-class PeriphUartUtil(object):
-    """Helper class for error message handling."""
-
-    @staticmethod
-    def uart_get_string(result):
-        """Return either an empty string if sending failed or received one."""
-        rcv_string = ''
-        if result['data'] is not None and result['data'][0]:
-            rcv_string = result['data'][0]
-
-        return rcv_string
-
-    def message_for_should_match(self, result, ref_string, stats):
-        """Create message for DUT Should Match String keyword."""
-        ret = ''
-        rcv_string = self.uart_get_string(result)
-        if result['result'] == 'Timeout':
-            ret = "Test timed out: " + stats
-        elif result['result'] == 'Success' and rcv_string != ref_string:
-            ret = "Reference string doesn't match the received one: " + stats
-        elif result['result'] == 'Error':
-            ret = "API call failed: " + result['msg']
-
-        return ret
-
-    def message_for_should_not_match(self, result, ref_string, stats):
-        """Create message for DUT Should Not Match String keyword."""
-        ret = ''
-        rcv_string = self.uart_get_string(result)
-        if result['result'] == 'Success' and rcv_string == ref_string:
-            ret = "No timeout occurred and the reference string " \
-                  "does match the received one: " + stats
-        elif result['result'] == 'Error':
-            ret = "API call failed: " + result['msg']
-
-        return ret

--- a/tests/xtimer_cli/tests/01__xtimer_base.robot
+++ b/tests/xtimer_cli/tests/01__xtimer_base.robot
@@ -6,6 +6,7 @@ Suite Setup         Run Keywords    RIOT Reset
 ...                                 API Firmware Should Match
 # reset application before running any test
 Test Setup          Run Keywords    RIOT Reset
+...                                 API Sync Shell
 
 # import libs and keywords
 Library             Xtimer  port=%{PORT}  baudrate=%{BAUD}  timeout=${10}


### PR DESCRIPTION
This adapts the periph_uart test to use existing keywords and be consistent with other tests.