### PR TITLE
tests: make shell cmd timeout configurable

### DIFF
--- a/tests/Makefile.tests_common
+++ b/tests/Makefile.tests_common
@@ -4,7 +4,9 @@ APPLICATION ?= tests_$(notdir $(patsubst %/,%,$(CURDIR)))
 TESTBASE ?= $(CURDIR)/../../
 RIOTBASE ?= $(TESTBASE)/RIOT
 BUILD_DIR ?= $(TESTBASE)/build
-
+# Default timeout for serial connection to a board
+CMD_TIMEOUT ?= 1
+export CMD_TIMEOUT
 # suppress output
 QUIET ?= 1
 # DEVELHELP enabled by default for all tests, set 0 to disable

--- a/tests/periph_i2c/tests/periph_i2c.keywords.txt
+++ b/tests/periph_i2c/tests/periph_i2c.keywords.txt
@@ -1,5 +1,5 @@
 *** Settings ***
-Library             I2Cdevice  port=%{PORT}  baudrate=%{BAUD}  timeout=${10}
+Library             I2Cdevice  port=%{PORT}  baudrate=%{BAUD}  timeout=${%{CMD_TIMEOUT}}
 
 Resource            api_shell.keywords.txt
 Resource            philip.keywords.txt

--- a/tests/periph_uart/tests/periph_uart.keywords.txt
+++ b/tests/periph_uart/tests/periph_uart.keywords.txt
@@ -1,5 +1,5 @@
 *** Settings ***
-Library             UartDevice  port=%{PORT}  baudrate=%{BAUD}  timeout=${10}
+Library             UartDevice  port=%{PORT}  baudrate=%{BAUD}  timeout=${%{CMD_TIMEOUT}}
 
 Resource            api_shell.keywords.txt
 Resource            philip.keywords.txt

--- a/tests/xtimer_cli/tests/01__xtimer_base.robot
+++ b/tests/xtimer_cli/tests/01__xtimer_base.robot
@@ -9,7 +9,7 @@ Test Setup          Run Keywords    RIOT Reset
 ...                                 API Sync Shell
 
 # import libs and keywords
-Library             Xtimer  port=%{PORT}  baudrate=%{BAUD}  timeout=${10}
+Library             Xtimer  port=%{PORT}  baudrate=%{BAUD}  timeout=${%{CMD_TIMEOUT}}
 Resource            api_shell.keywords.txt
 Resource            riot_base.keywords.txt
 


### PR DESCRIPTION
this should improve (i.e. lower) overall test runtime