### PR TITLE
feat(parser): Add a json shell parser with example

### DIFF
--- a/tests/Makefile.tests_common
+++ b/tests/Makefile.tests_common
@@ -1,7 +1,7 @@
 APPLICATION ?= tests_$(notdir $(patsubst %/,%,$(CURDIR)))
 
 # set and redirect default paths
-TESTBASE ?= $(CURDIR)/../../
+TESTBASE ?= $(CURDIR)/../..
 RIOTBASE ?= $(TESTBASE)/RIOT
 BUILD_DIR ?= $(TESTBASE)/build
 # Default timeout for serial connection to a board
@@ -13,6 +13,12 @@ QUIET ?= 1
 DEVELHELP ?= 1
 # expose extra metadata
 CFLAGS += -DRIOT_APPLICATION=\"$(APPLICATION)\"
+
+# Add the common folder for all common test helpers
+EXTERNAL_MODULE_DIRS += $(TESTBASE)/tests/common
+
+# All tests here _should_ use the test helpers
+USEMODULE += test_helpers
 
 # include RF specific settings
 include $(TESTBASE)/dist/robotframework/Makefile.include

--- a/tests/common/Makefile
+++ b/tests/common/Makefile
@@ -1,0 +1,2 @@
+MODULE = test_helpers
+include $(RIOTBASE)/Makefile.base

--- a/tests/common/Makefile.include
+++ b/tests/common/Makefile.include
@@ -1,0 +1,8 @@
+RF_TESTS_COMMON_DIR := $(abspath $(patsubst %/,%,$(dir $(lastword $(MAKEFILE_LIST)))))
+ifneq (,$(filter test_helpers,$(USEMODULE)))
+  USEMODULE_INCLUDES += $(RF_TESTS_COMMON_DIR)/include
+endif
+
+ifeq ($(USE_JSON_SHELL_PARSER),1)
+  CFLAGS += -DJSON_SHELL_PARSER
+endif

--- a/tests/common/include/test_helpers.h
+++ b/tests/common/include/test_helpers.h
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2019 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief       Test helpers for writing tests with standard interfaces.
+ *
+ * @author      Kevin Weiss <kevin.weiss@haw-hamburg.de>
+ *
+ * @}
+ */
+
+#include "shell.h"
+
+#ifndef TEST_HELPERS_H
+#define TEST_HELPERS_H
+
+#ifdef JSON_SHELL_PARSER
+/**
+ * @name    JSON_SHELL_PARSER states
+ *
+ * Used to control the state of writing json formatted message.
+ * @{
+ */
+#define JSON_STATE_READY            0
+#define JSON_STATE_STARTED          0x01
+#define JSON_STATE_DATA_STARTED     0x02
+/** @} */
+
+/**
+ * @brief   The number of json shell parsed in case using multiple threads
+ * @{
+ */
+#ifndef NUM_OF_JSON_SHELL_PARSER
+#define NUM_OF_JSON_SHELL_PARSER    1
+#endif
+/** @} */
+
+/**
+ * @brief   The version of parser being used
+ */
+#define APP_SHELL_FMT    "JSON_SHELL_PARSER_v0.0.0"
+
+#endif /* JSON_SHELL_PARSER */
+
+/**
+ * @name    TEST_RESULT standard states
+ *
+ * The proper message to send when things succeed or fail.
+ * @{
+ */
+#define TEST_RESULT_SUCCESS "SUCCESS"
+#define TEST_RESULT_ERROR   "ERROR"
+/** @} */
+
+/**
+ * @brief   Prints the command that was issued to the console
+ *
+ * The exact output depends on the parser but it will contain information on
+ * the command.
+ *
+ * @param[in] dev   parsing instance
+ * @param[in] cmd   string of the command
+ */
+void print_cmd(int dev, char *cmd);
+
+/**
+ * @brief   Prints a key value where the value is a string to the console
+ *
+ * The exact output depends on the parser but it will contain information on
+ * both the key and value.
+ *
+ * @param[in] dev   parsing instance
+ * @param[in] key   string of the key
+ * @param[in] val   string of the value
+ */
+void print_data_dict_str(int dev, char *key, char *val);
+
+/**
+ * @brief   Prints a int to the console
+ *
+ * The exact output depends on the parser but it will contain information on
+ * the integer.
+ *
+ * @param[in] dev   parsing instance
+ * @param[in] data  the integer data
+ */
+void print_data_int(int dev, int32_t data);
+
+/**
+ * @brief   Prints a string to the console
+ *
+ * The exact output depends on the parser but it will contain information on
+ * the string.
+ *
+ * @param[in] dev   parsing instance
+ * @param[in] str   the string data
+ */
+void print_data_str(int dev, char *str);
+
+/**
+ * @brief   Prints a result to the console
+ *
+ * The exact output depends on the parser but it will contain information on
+ * the string.
+ *
+ * @note    This must be used for some parsers to indicate end of command
+ *
+ * @param[in] dev   parsing instance
+ * @param[in] res   the TEST_RESULT string if SUCCESS or ERROR
+ */
+void print_result(int dev, char *res);
+
+#endif /* TEST_HELPERS_H */

--- a/tests/common/test_helpers.c
+++ b/tests/common/test_helpers.c
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2019 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief       Test helpers for writing tests with standard interfaces.
+ *
+ * @author      Kevin Weiss <kevin.weiss@haw-hamburg.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <inttypes.h>
+
+#include "test_helpers.h"
+
+#ifdef JSON_SHELL_PARSER
+static int parser_state[NUM_OF_JSON_SHELL_PARSER] = {0};
+#endif
+
+#ifdef JSON_SHELL_PARSER
+static void _start_json(int dev) {
+    if (parser_state[dev] == JSON_STATE_READY) {
+        printf("{");
+        parser_state[dev] |= JSON_STATE_STARTED;
+    }
+    else {
+        printf(",");
+    }
+}
+#endif
+
+void print_cmd(int dev, char *cmd)
+{
+#ifdef JSON_SHELL_PARSER
+    _start_json(dev);
+    assert(!(parser_state[dev] & JSON_STATE_DATA_STARTED));
+    printf("\"cmd\":\"%s\"", cmd);
+#else
+    (void)dev;
+    puts(cmd);
+#endif
+}
+
+void print_data_dict_str(int dev, char *key, char *val)
+{
+#ifdef JSON_SHELL_PARSER
+    _start_json(dev);
+    if (!(parser_state[dev] & JSON_STATE_DATA_STARTED))
+    {
+        printf("\"data\":[");
+        parser_state[dev] |= JSON_STATE_DATA_STARTED;
+    }
+    printf("{\"%s\":\"%s\"}", key, val);
+#else
+    (void)dev;
+    printf("%s: %s\n", key, val);
+#endif
+}
+
+void print_data_int(int dev, int32_t data)
+{
+#ifdef JSON_SHELL_PARSER
+    _start_json(dev);
+    if (!(parser_state[dev] & JSON_STATE_DATA_STARTED))
+    {
+        printf("\"data\":[");
+        parser_state[dev] |= JSON_STATE_DATA_STARTED;
+    }
+    printf("%li", data);
+#else
+    (void)dev;
+    printf("%li\n", data);
+#endif
+}
+
+void print_data_str(int dev, char *str)
+{
+#ifdef JSON_SHELL_PARSER
+    _start_json(dev);
+    if (!(parser_state[dev] & JSON_STATE_DATA_STARTED))
+    {
+        printf("\"data\":[");
+        parser_state[dev] |= JSON_STATE_DATA_STARTED;
+    }
+    printf("\"%s\"", str);
+#else
+    (void)dev;
+    puts(str);
+#endif
+}
+
+void print_result(int dev, char *res)
+{
+#ifdef JSON_SHELL_PARSER
+    if ((parser_state[dev] & JSON_STATE_DATA_STARTED))
+    {
+        printf("]");
+        parser_state[dev] &= ~JSON_STATE_DATA_STARTED;
+    }
+    _start_json(dev);
+    printf("\"result\":\"%s\"}\n", res);
+    parser_state[dev] &= ~JSON_STATE_STARTED;
+#else
+    (void)dev;
+    puts(res);
+#endif
+}

--- a/tests/if_parser/Makefile
+++ b/tests/if_parser/Makefile
@@ -1,0 +1,8 @@
+include ../Makefile.tests_common
+
+USEMODULE += shell
+USE_JSON_SHELL_PARSER ?= 1
+
+CFLAGS += -DRIOT_APPLICATION=\"$(APPLICATION)\"
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/if_parser/README.md
+++ b/tests/if_parser/README.md
@@ -1,0 +1,24 @@
+# Interface Parser Test
+
+This application enables testing of different parsers provided by `riot_pal`.
+
+### Setup
+If the [Robot Framework Setup](../../README.md) was followed then `riot_pal`
+should already be installed.
+Ensure the version is greater or equal to `0.3.0`.
+To upgrade or install use `pip3 install --upgrade riot_pal`
+
+## Running Tests Manually
+
+To run tests manually simply call each command and verify the result.
+
+### Using riot_pal For Manual Tests
+
+The default setting has `USE_JSON_SHELL_PARSER=1` which formats the firmware
+to output json.
+The default parser for the `dut_pyshell` is also json.
+If the parsers match then the command list should be able to autocomplete.
+
+### Using Standard Terminal For Manual Tests
+
+If using a standard terminal the unparsed data will be available.

--- a/tests/if_parser/main.c
+++ b/tests/if_parser/main.c
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2019 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for the basic parsing tests
+ *
+ * @author      Kevin Weiss <kevin.weiss@haw-hamburg.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "shell.h"
+#include "test_helpers.h"
+
+#ifndef PARSER_DEV_NUM
+#define PARSER_DEV_NUM 0
+#endif
+
+void print_app_metadata(int dev)
+{
+    print_cmd(dev,"app_metadata()");
+    print_data_dict_str(dev, "app_name", RIOT_APPLICATION);
+    print_data_dict_str(dev, "board", RIOT_BOARD);
+    print_data_dict_str(dev, "cpu", RIOT_CPU);
+#ifdef APP_SHELL_FMT
+    print_data_dict_str(dev, "app_shell_fmt", APP_SHELL_FMT);
+#endif
+    print_data_dict_str(dev, "mcu", RIOT_MCU);
+    print_data_dict_str(dev, "os_version", RIOT_VERSION);
+    print_result(dev, TEST_RESULT_SUCCESS);
+}
+
+int cmd_app_metadata(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+    print_app_metadata(PARSER_DEV_NUM);
+    return 0;
+}
+
+int cmd_test_result_only(int argc, char **argv)
+{
+    (void)argv;
+    if (argc > 1) {
+        print_result(PARSER_DEV_NUM, TEST_RESULT_ERROR);
+    }
+    else {
+        print_result(PARSER_DEV_NUM, TEST_RESULT_SUCCESS);
+    }
+    return 0;
+}
+
+int cmd_test_cmd(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+    print_cmd(PARSER_DEV_NUM,"test_cmd()");
+    print_result(PARSER_DEV_NUM, TEST_RESULT_SUCCESS);
+    return 0;
+}
+
+int cmd_test_data_int(int argc, char **argv)
+{
+    for (int i = 1; i < argc; i++) {
+        print_data_int(PARSER_DEV_NUM, atoi(argv[i]));
+    }
+    print_result(PARSER_DEV_NUM, TEST_RESULT_SUCCESS);
+    return 0;
+}
+
+int cmd_test_data_str(int argc, char **argv)
+{
+    for (int i = 1; i < argc; i++) {
+        print_data_str(PARSER_DEV_NUM, argv[i]);
+    }
+    print_result(PARSER_DEV_NUM, TEST_RESULT_SUCCESS);
+    return 0;
+}
+
+#ifdef JSON_SHELL_PARSER
+/* Needs a foward declaration since we use shell_commands */
+int cmd_help(int argc, char **argv);
+#endif
+
+static const shell_command_t shell_commands[] = {
+    { "app_metadata", "Gets application metadata", cmd_app_metadata },
+    { "test_result_only", "Test only result", cmd_test_result_only },
+    { "test_cmd", "Test commands", cmd_test_cmd },
+    { "test_data_int", "Test integers", cmd_test_data_int },
+    { "test_data_str", "Test strings", cmd_test_data_str },
+#ifdef JSON_SHELL_PARSER
+    { "help", "Print command list", cmd_help },
+#endif
+    { NULL, NULL, NULL }
+};
+
+
+#ifdef JSON_SHELL_PARSER
+int cmd_help(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+    for (unsigned int i = 0; shell_commands[i].name != NULL; i++) {
+        print_data_str(PARSER_DEV_NUM, (char*)shell_commands[i].name);
+    }
+    print_result(PARSER_DEV_NUM, TEST_RESULT_SUCCESS);
+    return 0;
+}
+#endif
+
+
+int main(void)
+{
+    puts("Running app_metadata test firmware\n");
+
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    return 0;
+}


### PR DESCRIPTION
## Description
This adds a common test helpers module
The test helpers has a way to set human readable or json parsing
An app_metadata test is provided as an example

## Testing procedure
1. `BOARD=<board_of_your_choice> make flash term -C tests/if_parser`
2. Go through each command with in `help`
3. Everything should have json formatted results
4. Compile with `USE_JSON_SHELL_PARSER=0`
5. Check all commands again for human readable output
