### PR TITLE
tests/periph_timer: fix resets in test setup

### DIFF
--- a/tests/periph_timer/tests/01__periph_timer_base.robot
+++ b/tests/periph_timer/tests/01__periph_timer_base.robot
@@ -2,10 +2,12 @@
 Documentation       Verify basic functionality of the Periph Timer API.
 
 # reset application and check DUT has correct firmware, skip all tests on error
-Suite Setup         Run Keywords    PHiLIP.DUT Reset
+Suite Setup         Run Keywords    PHILIP Reset
+...                                 RIOT Reset
 ...                                 API Firmware Should Match
 # reset application before running any test
-Test Setup          Run Keywords    PHiLIP.DUT Reset
+Test Setup          Run Keywords    PHILIP Reset
+...                                 RIOT Reset
 ...                                 API Sync Shell
 
 # import libs and keywords

--- a/tests/periph_timer/tests/02__periph_timer_extra.robot
+++ b/tests/periph_timer/tests/02__periph_timer_extra.robot
@@ -2,10 +2,12 @@
 Documentation       Verify basic functionality of the Periph Timer API.
 
 # reset application and check DUT has correct firmware, skip all tests on error
-Suite Setup         Run Keywords    PHiLIP.DUT Reset
+Suite Setup         Run Keywords    PHILIP Reset
+...                                 RIOT Reset
 ...                                 API Firmware Should Match
 # reset application before running any test
-Test Setup          Run Keywords    PHiLIP.DUT Reset
+Test Setup          Run Keywords    PHILIP Reset
+...                                 RIOT Reset
 ...                                 API Sync Shell
 ...                                 Timer Debug Pin
 

--- a/tests/periph_timer/tests/03__periph_timer_set_delays.robot
+++ b/tests/periph_timer/tests/03__periph_timer_set_delays.robot
@@ -2,11 +2,12 @@
 Documentation       Evaluate Delays for numerous timer_set values.
 
 # reset application and check DUT has correct firmware, skip all tests on error
-Suite Setup         Run Keywords    PHiLIP.DUT Reset
+Suite Setup         Run Keywords    PHILIP Reset
+...                                 RIOT Reset
 ...                                 API Firmware Should Match
 # reset application before running any test
-Test Setup          Run Keywords    PHiLIP.DUT Reset
-...                                 PHILIP Reset
+Test Setup          Run Keywords    PHILIP Reset
+...                                 RIOT Reset
 ...                                 API Sync Shell
 # set test template for data driver tests
 Test Template       Measure Timer Set Delay


### PR DESCRIPTION
The suite and test setup were different from the other tests. First they didn't reset philip all the time and also didn't use "RIOT Reset" for DUT. This is fixed here, that should resolve some weird errors we saw with some boards, e.g. remote-revb.