### PR TITLE
tests/periph_gpio: Add periph gpio test for debug pin checks

### DIFF
--- a/tests/periph_gpio/Makefile
+++ b/tests/periph_gpio/Makefile
@@ -1,0 +1,7 @@
+include ../Makefile.tests_common
+
+FEATURES_REQUIRED = periph_gpio
+
+USEMODULE += shell
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/periph_gpio/main.c
+++ b/tests/periph_gpio/main.c
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2019 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for GPIO peripheral drivers
+ *
+ * @author      Kevin Weiss <kevin.weiss@haw-hamuburg.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "shell.h"
+#include "periph/gpio.h"
+
+
+static int set(int argc, char **argv)
+{
+    if (argc < 3) {
+        printf("usage: %s <port> <pin>\n", argv[0]);
+        return 1;
+    }
+    gpio_init(GPIO_PIN(atoi(argv[1]), atoi(argv[2])), GPIO_OUT);
+    gpio_set(GPIO_PIN(atoi(argv[1]), atoi(argv[2])));
+    printf("Success: Pin set\n");
+    return 0;
+}
+
+static int clear(int argc, char **argv)
+{
+    if (argc < 3) {
+        printf("usage: %s <port> <pin>\n", argv[0]);
+        return 1;
+    }
+    gpio_init(GPIO_PIN(atoi(argv[1]), atoi(argv[2])), GPIO_OUT);
+    gpio_clear(GPIO_PIN(atoi(argv[1]), atoi(argv[2])));
+    printf("Success: Pin cleared\n");
+    return 0;
+}
+
+int cmd_get_metadata(int argc, char **argv)
+{
+    (void)argv;
+    (void)argc;
+
+    printf("Success: [%s, %s]\n", RIOT_BOARD, RIOT_APPLICATION);
+
+    return 0;
+}
+
+static const shell_command_t shell_commands[] = {
+    { "gpio_set", "set pin to HIGH", set },
+    { "gpio_clear", "set pin to LOW", clear },
+    { "get_metadata", "Get the metadata of the test firmware", cmd_get_metadata },
+    { NULL, NULL, NULL }
+};
+
+int main(void)
+{
+    /* start the shell */
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    return 0;
+}

--- a/tests/periph_gpio/tests/01__periph_gpio_base.robot
+++ b/tests/periph_gpio/tests/01__periph_gpio_base.robot
@@ -1,0 +1,20 @@
+*** Settings ***
+Documentation       Verify if board to philip wiring is correct.
+
+Suite Setup         Run Keywords    PHILIP Reset
+...                                 RIOT Reset
+...                                 API Firmware Should Match
+Test Setup          Run Keywords    PHILIP Reset
+...                                 RIOT Reset
+...                                 API Sync Shell
+
+Test Template       Verify GPIO Pin Is Connected
+
+Resource            periph_gpio.keywords.txt
+
+Force Tags          periph  gpio
+
+*** Test Cases ***  PHILIP_GPIO             DUT_PORT        DUT_PIN
+Verify GPIO_0       gpio[0].status.level    %{DEBUG0_PORT}  %{DEBUG0_PIN}
+Verify GPIO_1       gpio[1].status.level    %{DEBUG1_PORT}  %{DEBUG1_PIN}
+Verify GPIO_2       gpio[2].status.level    %{DEBUG2_PORT}  %{DEBUG2_PIN}

--- a/tests/periph_gpio/tests/GPIOdevice.py
+++ b/tests/periph_gpio/tests/GPIOdevice.py
@@ -1,0 +1,8 @@
+from periph_gpio_if import PeriphGpioIf
+from robot.version import get_version
+
+
+class GPIOdevice(PeriphGpioIf):
+
+    ROBOT_LIBRARY_SCOPE = 'TEST SUITE'
+    ROBOT_LIBRARY_VERSION = get_version()

--- a/tests/periph_gpio/tests/periph_gpio.keywords.txt
+++ b/tests/periph_gpio/tests/periph_gpio.keywords.txt
@@ -1,0 +1,16 @@
+*** Settings ***
+Library             GPIOdevice  port=%{PORT}  baudrate=%{BAUD}  timeout=${%{CMD_TIMEOUT}}  connect_wait=${%{CONNECT_WAIT}}
+
+Resource            api_shell.keywords.txt
+Resource            philip.keywords.txt
+
+*** Keywords ***
+Verify GPIO Pin Is Connected
+    [Documentation]             Verify DUT pin is connected to PHiLIP pin with toggle.
+    [Arguments]                 ${phil_gpio}       ${dut_port}   ${dut_pin}
+    API Call Should Succeed     GPIO Set           ${dut_port}   ${dut_pin}
+    API Call Should Succeed     PHiLIP.Read Reg    ${phil_gpio}
+    Should Be Equal             ${RESULT['data']}  ${1}
+    API Call Should Succeed     GPIO Clear         ${dut_port}   ${dut_pin}
+    API Call Should Succeed     PHiLIP.Read Reg    ${phil_gpio}
+    Should Be Equal             ${RESULT['data']}  ${0}

--- a/tests/periph_gpio/tests/periph_gpio_if.py
+++ b/tests/periph_gpio/tests/periph_gpio_if.py
@@ -1,0 +1,50 @@
+# Copyright (C) 2019 Kevin Weiss <kevin.weiss@haw-hamburg.de>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+"""@package PyToAPI
+This module handles parsing of information from RIOT periph_gpio test.
+"""
+from riot_pal import DutShell
+
+
+class PeriphGpioIf(DutShell):
+    """Interface to the a node with periph_i2c firmware."""
+
+    FW_ID = 'periph_gpio'
+
+    @staticmethod
+    def _convert_port_to_num(port):
+        port = str(port).upper()
+        port = port.strip("PORT_")
+        port = port.strip("PORT")
+        port = port.strip("P_")
+        port = port.strip("P")
+        if ord(port[0]) >= ord('A') and ord(port[0]) <= ord('Z'):
+            port = ord(port[0]) - ord('A')
+        return int(port)
+
+    def gpio_set(self, port, pin):
+        """Set the GPIO port and pin to HIGH."""
+
+        return self.send_cmd('gpio_set {} {}'
+                             .format(self._convert_port_to_num(port), pin))
+
+    def gpio_clear(self, port, pin):
+        """Clear the GPIO port and pin to LOW."""
+
+        return self.send_cmd('gpio_clear {} {}'
+                             .format(self._convert_port_to_num(port), pin))
+
+    def get_metadata(self):
+        """Get the metadata of the firmware."""
+        return self.send_cmd('get_metadata')
+
+    def get_command_list(self):
+        """List of all commands."""
+        cmds = list()
+        cmds.append(self.gpio_set)
+        cmds.append(self.gpio_clear)
+        cmds.append(self.get_metadata)
+        return cmds


### PR DESCRIPTION
## Description

This adds some firmware and interface for periph GPIO
It also has a robot test to check if the debug pins are correct

This can serve as a basis for other GPIO tests but is immediatly useful to test if the debug pins in a CI are correct.
This can be used in the future to check if the `gpio_init` can override pins initialized with af such as SPI and I2C pins.  PHiLIP must first be upgraded to read the values of each of the pins.

The gpio port can be written a number of ways which gets taken care of in the python interface.

```
PORT_A
PORTA
P_A
PA
P0
0
```


## Testing Procedure

What I did:
`DEBUG0_PORT=P1 DEBUG0_PIN=5 DEBUG1_PORT=P_B DEBUG1_PIN=3 DEBUG2_PORT=PA DEBUG2_PIN=12 PHILIP_PORT=/dev/ttyACM1 PORT=/dev/ttyACM0 BOARD=nucleo-l433rc make robot-clean robot-test robot-html -C tests/periph_gpio/`

Generalized (fill in your own ?):
`DEBUG0_PORT=? DEBUG0_PIN=? DEBUG1_PORT=? DEBUG1_PIN=? DEBUG2_PORT=? DEBUG2_PIN=? PHILIP_PORT=? PORT=? BOARD=? make robot-clean robot-test robot-html -C tests/periph_gpio/`