### PR TITLE
tests/periph_uart: Expose uart dev and clean

### DIFF
--- a/tests/periph_uart/Makefile
+++ b/tests/periph_uart/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno nucleo-f031k6
+export RF_UART_DEV ?= 1
 
 FEATURES_REQUIRED += periph_uart
 FEATURES_OPTIONAL += periph_lpuart  # STM32 L0 and L4 provides lpuart support

--- a/tests/periph_uart/tests/01__periph_uart_base.robot
+++ b/tests/periph_uart/tests/01__periph_uart_base.robot
@@ -18,71 +18,71 @@ Force Tags          periph  uart
 *** Test Cases ***
 Short Echo Should Succeed
     [Documentation]     Write short string to UART and verify echo reply.
-    PHILIP.Setup Uart
+    PHILIP Setup UART
     UART Init and Flush Should Succeed
-    API Call Should Succeed     Uart Write  ${SHORT_TEST_STRING}
+    Uart Write Should Succeed       ${SHORT_TEST_STRING}
     API Result Data Should Contain  ${SHORT_TEST_STRING}
     PHILIP Log Stats
 
 Long Echo Should Succeed
     [Documentation]     Write long string to UART and verify echo reply.
-    PHILIP.Setup Uart
+    PHILIP Setup UART
     UART Init and Flush Should Succeed
-    API Call Should Succeed     Uart Write  ${LONG_TEST_STRING}
+    Uart Write Should Succeed       ${LONG_TEST_STRING}
     API Result Data Should Contain  ${LONG_TEST_STRING}
     PHILIP Log Stats
 
 Extended Short Echo Should Succeed
     [Documentation]     Verify echo of short string to UART.
-    PHILIP.Setup Uart           mode=1
+    PHILIP Setup UART  mode=1
     UART Init and Flush Should Succeed
-    API Call Should Succeed     Uart Write  ${SHORT_TEST_STRING}
+    Uart Write Should Succeed       ${SHORT_TEST_STRING}
     API Result Data Should Contain  ${SHORT_TEST_STRING_INC}
     PHILIP Log Stats
 
 Extended Long Echo Should Succeed
     [Documentation]     Verify echo of long string to UART.
-    PHILIP.Setup Uart           mode=1
+    PHILIP Setup UART  mode=1
     UART Init and Flush Should Succeed
-    API Call Should Succeed     Uart Write  ${LONG_TEST_STRING}
+    Uart Write Should Succeed       ${LONG_TEST_STRING}
     API Result Data Should Contain  ${LONG_TEST_STRING_INC}
     PHILIP Log Stats
 
 Register Access Should Succeed
     [Documentation]     Verify access of user register via UART.
-    PHILIP.Setup Uart           mode=2
+    PHILIP Setup UART  mode=2
     UART Init and Flush Should Succeed
-    API Call Should Succeed     Uart Write          ${REG_USER_READ}
-    Should Be Equal             ${RESULT['data']}   ${REG_USER_READ_DATA}
+    Uart Write Should Succeed   ${REG_USER_READ}
+    Should Be Equal             ${RESULT['data']}  ${REG_USER_READ_DATA}
     PHILIP Log Stats
 
 Invalid Register Access Should Fail
     [Documentation]     Verfiy access of invalid register via UART fails.
-    PHILIP.Setup Uart           mode=2
+    PHILIP Setup UART           mode=2
     UART Init and Flush Should Succeed
-    API Call Should Succeed     Uart Write          ${REG_WRONG_READ}
-    Should Be Equal             ${RESULT['data']}   ${REG_WRONG_READ_DATA}
+    Uart Write Should Succeed   ${REG_WRONG_READ}
+    Should Be Equal             ${RESULT['data']}  ${REG_WRONG_READ_DATA}
     PHILIP Log Stats
 
 Baudrate 9600 Should Succeed
     [Documentation]     Verify UART write with baudrate 9600.
-    PHILIP.Setup Uart           baudrate=9600
+    PHILIP Setup UART                       baudrate=9600
     UART Init and Flush Should Succeed      baud=${9600}
-    API Call Should Succeed     Uart Write  ${SHORT_TEST_STRING}
-    API Result Data Should Contain  ${SHORT_TEST_STRING}
+    Uart Write Should Succeed               ${SHORT_TEST_STRING}
+    API Result Data Should Contain          ${SHORT_TEST_STRING}
     PHILIP Log Stats
 
 Baudrate 38400 Should Succeed
     [Documentation]     Verify UART write with baudrate 38400.
-    PHILIP.Setup Uart           baudrate=38400
+    PHILIP Setup UART                       baudrate=38400
     UART Init and Flush Should Succeed      baud=${38400}
-    API Call Should Succeed     Uart Write  ${SHORT_TEST_STRING}
-    API Result Data Should Contain  ${SHORT_TEST_STRING}
+    Uart Write Should Succeed               ${SHORT_TEST_STRING}
+    API Result Data Should Contain          ${SHORT_TEST_STRING}
     PHILIP Log Stats
 
 Baudrate Mismatch Should Fail
     [Documentation]     Verify UART write fails when baudrates do not match.
-    PHILIP.Setup Uart           baudrate=9600
+    PHILIP Setup UART                       baudrate=9600
     UART Init and Flush Should Succeed      baud=${38400}
-    API Call Should Timeout     Uart Write  ${SHORT_TEST_STRING}
+    Uart Write Should Timeout               ${SHORT_TEST_STRING}
     PHILIP Log Stats

--- a/tests/periph_uart/tests/02__periph_uart_mode.robot
+++ b/tests/periph_uart/tests/02__periph_uart_mode.robot
@@ -19,55 +19,55 @@ Force Tags          periph  uart
 Even Parity with 8 Bits Should Succeed
     [Documentation]     Verify UART mode with 8 data bits and even parity.
     UART Mode Should Exist
-    PHILIP.Setup Uart           parity=${UART_PARITY_EVEN}
-    UART Mode Change Should Succeed         data_bits=8  parity="E"  stop_bits=1
-    API Call Should Succeed     Uart Write  ${SHORT_TEST_STRING}
-    API Result Data Should Contain  ${SHORT_TEST_STRING}
-    UART Mode Change Should Succeed         data_bits=8  parity="O"  stop_bits=1
-    API Call Should Timeout     Uart Write  ${SHORT_TEST_STRING}
+    PHILIP Setup UART                   parity=${UART_PARITY_EVEN}
+    UART Mode Change Should Succeed     data_bits=8  parity="E"  stop_bits=1
+    Uart Write Should Succeed           ${SHORT_TEST_STRING}
+    API Result Data Should Contain      ${SHORT_TEST_STRING}
+    UART Mode Change Should Succeed     data_bits=8  parity="O"  stop_bits=1
+    Uart Write Should Timeout           ${SHORT_TEST_STRING}
     PHILIP Log Stats
 
 Odd Parity with 8 Bits Should Succeed
     [Documentation]     Verify UART mode with 8 data bits and odd parity.
     UART Mode Should Exist
-    PHILIP.Setup Uart           parity=${UART_PARITY_ODD}
-    UART Mode Change Should Succeed         data_bits=8  parity="O"  stop_bits=1
-    API Call Should Succeed     Uart Write  ${SHORT_TEST_STRING}
-    API Result Data Should Contain  ${SHORT_TEST_STRING}
-    UART Mode Change Should Succeed         data_bits=8  parity="E"  stop_bits=1
-    API Call Should Timeout     Uart Write  ${SHORT_TEST_STRING}
+    PHILIP Setup UART                   parity=${UART_PARITY_ODD}
+    UART Mode Change Should Succeed     data_bits=8  parity="O"  stop_bits=1
+    Uart Write Should Succeed           ${SHORT_TEST_STRING}
+    API Result Data Should Contain      ${SHORT_TEST_STRING}
+    UART Mode Change Should Succeed     data_bits=8  parity="E"  stop_bits=1
+    Uart Write Should Timeout           ${SHORT_TEST_STRING}
     PHILIP Log Stats
 
 Even Parity with 7 Bits Should Succeed
     [Documentation]     Verify UART mode with 7 data bits and even parity.
     UART Mode Should Exist
-    PHILIP.Setup Uart           parity=${UART_PARITY_EVEN}   databits=${UART_DATA_BITS_7}
-    UART Mode Change Should Succeed         data_bits=7  parity="E"  stop_bits=1
-    API Call Should Succeed     Uart Write  ${SHORT_TEST_STRING}
-    API Result Data Should Contain  ${SHORT_TEST_STRING}
-    UART Mode Change Should Succeed         data_bits=7  parity="O"  stop_bits=1
-    API Call Should Timeout     Uart Write  ${SHORT_TEST_STRING}
+    PHILIP Setup UART                   parity=${UART_PARITY_EVEN}  databits=${UART_DATA_BITS_7}
+    UART Mode Change Should Succeed     data_bits=7  parity="E"  stop_bits=1
+    Uart Write Should Succeed           ${SHORT_TEST_STRING}
+    API Result Data Should Contain      ${SHORT_TEST_STRING}
+    UART Mode Change Should Succeed     data_bits=7  parity="O"  stop_bits=1
+    Uart Write Should Timeout           ${SHORT_TEST_STRING}
     PHILIP Log Stats
 
 Odd Parity with 7 Bits Should Succeed
     [Documentation]     Verify UART mode with 7 data bits and odd parity.
     UART Mode Should Exist
-    PHILIP.Setup Uart           parity=${UART_PARITY_ODD}   databits=${UART_DATA_BITS_7}
-    UART Mode Change Should Succeed         data_bits=7  parity="O"  stop_bits=1
-    API Call Should Succeed     Uart Write  ${SHORT_TEST_STRING}
-    API Result Data Should Contain  ${SHORT_TEST_STRING}
-    UART Mode Change Should Succeed         data_bits=7  parity="E"  stop_bits=1
-    API Call Should Timeout     Uart Write  ${SHORT_TEST_STRING}
+    PHILIP Setup UART                   parity=${UART_PARITY_ODD}  databits=${UART_DATA_BITS_7}
+    UART Mode Change Should Succeed     data_bits=7  parity="O"  stop_bits=1
+    Uart Write Should Succeed           ${SHORT_TEST_STRING}
+    API Result Data Should Contain      ${SHORT_TEST_STRING}
+    UART Mode Change Should Succeed     data_bits=7  parity="E"  stop_bits=1
+    Uart Write Should Timeout           ${SHORT_TEST_STRING}
     PHILIP Log Stats
 
 Write With Two Stop Bits Should Succeed
     [Documentation]     Verify UART mode with 2 stops bits.
     UART Mode Should Exist
-    PHILIP.Setup Uart           parity=${UART_PARITY_ODD}
-    UART Mode Change Should Succeed         data_bits=8  parity="N"  stop_bits=2
-    API Call Should Succeed     Uart Write  ${TEST_STRING_FOR_STOP_BITS}
-    API Result Data Should Contain  ${TEST_STRING_FOR_STOP_BITS}
-    UART Mode Change Should Succeed         data_bits=8  parity="N"  stop_bits=1
-    API Call Should Succeed     Uart Write  ${TEST_STRING_FOR_STOP_BITS}
+    PHILIP Setup UART                   parity=${UART_PARITY_ODD}
+    UART Mode Change Should Succeed     data_bits=8  parity="N"  stop_bits=2
+    Uart Write Should Succeed           ${TEST_STRING_FOR_STOP_BITS}
+    API Result Data Should Contain      ${TEST_STRING_FOR_STOP_BITS}
+    UART Mode Change Should Succeed     data_bits=8  parity="N"  stop_bits=1
+    Uart Write Should Succeed           ${TEST_STRING_FOR_STOP_BITS}
     API Result Data Should Not Contain  ${TEST_STRING_FOR_STOP_BITS}
     PHILIP Log Stats

--- a/tests/periph_uart/tests/periph_uart.keywords.txt
+++ b/tests/periph_uart/tests/periph_uart.keywords.txt
@@ -8,22 +8,38 @@ Resource            riot_base.keywords.txt
 *** Keywords ***
 UART Flush
     [Documentation]             Remove garbage from UART buffer
-    UART write  flush
+    UART write  %{RF_UART_DEV}  flush
 
 UART Init and Flush Should Succeed
     [Documentation]             Init UART device and flush buffer
     [Arguments]                 @{args}  &{kwargs}
-    API Call Should Succeed     Uart Init   @{args}  &{kwargs}
+    API Call Should Succeed     Uart Init  %{RF_UART_DEV}  @{args}  &{kwargs}
     UART Flush
 
 UART Mode Change Should Succeed
     [Documentation]             Configure UART mode and flush
     [Arguments]                 @{args}  &{kwargs}
-    API Call Should Succeed     Uart Init
-    API Call Should Succeed     Uart Mode   @{args}  &{kwargs}
+    API Call Should Succeed     Uart Init  %{RF_UART_DEV}
+    API Call Should Succeed     Uart Mode  %{RF_UART_DEV}  @{args}  &{kwargs}
     UART Flush
+
+UART Write Should Succeed
+    [Documentation]             Write string to RF_UART_DEV should succeed
+    [Arguments]                 @{args}  &{kwargs}
+    API Call Should Succeed     Uart Write  %{RF_UART_DEV}  @{args}  &{kwargs}
+
+UART Write Should Timeout
+    [Documentation]             Write string to RF_UART_DEV should timeout
+    [Arguments]                 @{args}  &{kwargs}
+    API Call Should Timeout     Uart Write  %{RF_UART_DEV}  @{args}  &{kwargs}
 
 UART Mode Should Exist
     [Documentation]             Verify DUT supports UART mode configuration
-    ${status}   ${value}=       Run Keyword And Ignore Error   API Call Should Succeed   Uart Mode
+    ${status}   ${value}=       Run Keyword And Ignore Error   API Call Should Succeed   Uart Mode  %{RF_UART_DEV}
     Pass Execution If           '${status}'=='FAIL'   Feature is not supported
+
+PHILIP Setup UART
+    [Documentation]             Setup uart parameters on PHiLIP
+    [Arguments]                 @{args}  &{kwargs}
+    ${RESULT}=                  PHILIP.Setup Uart  @{args}  &{kwargs}
+    Log                         ${RESULT}

--- a/tests/periph_uart/tests/periph_uart_if.py
+++ b/tests/periph_uart/tests/periph_uart_if.py
@@ -15,26 +15,25 @@ class PeriphUartIf(DutShell):
     """Interface to the node with periph_uart firmware."""
 
     FW_ID = 'periph_uart'
-    DEFAULT_DEV = 1
     DEFAULT_BAUD = 115200
     DEFAULT_PARITY = 'N'
     DEFAULT_DATA_BITS = 8
     DEFAULT_STOP_BITS = 1
 
-    def uart_init(self, dev=DEFAULT_DEV, baud=DEFAULT_BAUD):
+    def uart_init(self, dev, baud=DEFAULT_BAUD):
         """Init UART device"""
         ret = self.send_cmd("uart_init {} {}".format(dev, baud))
         # Clear buffer from init by sending and receiving
         self.send_cmd("uart_write {} {}".format(dev, "flush"))
         return ret
 
-    def uart_mode(self, data_bits=DEFAULT_DATA_BITS, parity=DEFAULT_PARITY,
-                  stop_bits=DEFAULT_STOP_BITS, dev=DEFAULT_DEV):
+    def uart_mode(self, dev, data_bits=DEFAULT_DATA_BITS, parity=DEFAULT_PARITY,
+                  stop_bits=DEFAULT_STOP_BITS):
         """Setup databits, parity and stopbits."""
         return self.send_cmd(
             "uart_mode {} {} {} {}".format(dev, data_bits, parity, stop_bits))
 
-    def uart_write(self, data, dev=DEFAULT_DEV):
+    def uart_write(self, dev, data):
         """Write data to UART device."""
         return self.send_cmd("uart_write {} {}".format(dev, data))
 
@@ -50,23 +49,3 @@ class PeriphUartIf(DutShell):
         cmds.append(self.uart_mode)
         cmds.append(self.uart_write)
         return cmds
-
-
-def main():
-    """Test for PeriphUartIf."""
-
-    logging.getLogger().setLevel(logging.DEBUG)
-    try:
-        uart = PeriphUartIf()
-        cmds = uart.get_command_list()
-        logging.debug("======================================================")
-        for cmd in cmds:
-            cmd()
-            logging.debug("--------------------------------------------------")
-        logging.debug("======================================================")
-    except Exception as exc:
-        logging.debug(exc)
-
-
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
## Purpose
We should have a way to specify the device.  In the case of the `slstk3401a` the UART dev 1 pins are used by the SPI dev 0, with this we should be able to specify UART dev 2 for this board only.

## Description
Expose uart dev with the RF_UART_DEV environment variable
Add logging for the setup philip command
Align and clean tests
Remove unusable __main__ local test
Remove `BOARD_INSUFFICIENT_MEMORY`

## Testing Procedure
Let the CI test

