### PR TITLE
dist/tools: Add tool to print current setup

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,6 +44,11 @@ def stepClone()
     }
 }
 
+def stepPrintEnv(board, test)
+{
+    sh 'dist/tools/ci/print_environment.sh'
+}
+
 def stepReset(board, test)
 {
     sh "python3 -m bph_pal --philip_reset"
@@ -77,6 +82,7 @@ def parallelSteps (board, test) {
         node (board) {
             catchError() {
                 stepClone()
+                stepPrintEnv(board, test)
                 stepReset(board, test)
                 stepFlash(board, test)
                 stepTests(board, test)

--- a/dist/tools/ci/print_environment.py
+++ b/dist/tools/ci/print_environment.py
@@ -1,0 +1,38 @@
+#! /usr/bin/env python3
+import pkg_resources
+import os
+
+specific_keys = ["PORT", "PATH"]
+accepted_keys = ["DEBUG", "PHILIP", "BPH", "BOARD", "HIL", "RIOT", 
+                 "DUT", "RF_", "RESET", "ESP", "WAIT", "JLINK", "PERIPH",
+                 "OPENOCD", "FLASH", "PYTHON"]
+
+safe_env_vars = {}
+for key in specific_keys:
+    safe_env_vars[key] = os.environ.get(key)
+for key in os.environ.keys():
+    if any(accepted_key in key for accepted_key in accepted_keys):
+        safe_env_vars[key] = os.environ[key]
+
+header_name = "Environment Variables"
+print(header_name)
+print(len(header_name) * '-')       
+for k, v in safe_env_vars.items():
+    print("{: >23}: {}".format(k, v))
+print("")
+
+
+py_modules = ['riot_pal', 'philip_pal', 'robotframework', 'pyserial',
+              'wiringpi', 'smbus', 'deepdiff']
+py_versions = {}
+for pm in py_modules:
+    try:
+        py_versions[pm] = pkg_resources.get_distribution(pm).version
+    except pkg_resources.DistributionNotFound as exc:
+        py_versions[pm] = 'None'
+
+header_name = "Python Package Versions"
+print(header_name)
+print(len(header_name) * '-')
+for k, v in py_versions.items():
+    print("{: >23}: {}".format(k, v))

--- a/dist/tools/ci/print_environment.sh
+++ b/dist/tools/ci/print_environment.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+python3 $SCRIPTPATH/print_python_versions.py
+bash $SCRIPTPATH/../../../RIOT/dist/tools/ci/print_toolchain_versions.sh


### PR DESCRIPTION
## Description
This PR adds a script to print out the environment variables, python packages being used, and the toolchains being used.  It also adds a call for Jenkins to print the information.

## Testing Proceedure
Call the `dist/tools/print_versions.sh` from different directories.
~Also read the CI output.~ <- Not included in the CI yet
