### PR TITLE
tests/common/test_helpers: Fix printf casting

### DIFF
--- a/tests/common/test_helpers.c
+++ b/tests/common/test_helpers.c
@@ -78,10 +78,10 @@ void print_data_int(int dev, int32_t data)
         printf("\"data\":[");
         parser_state[dev] |= JSON_STATE_DATA_STARTED;
     }
-    printf("%li", data);
+    printf("%" PRIi32, data);
 #else
     (void)dev;
-    printf("%li\n", data);
+    printf("%" PRIi32 "\n", data);
 #endif
 }
 


### PR DESCRIPTION
## Description
Explicitly state print an int32 with PRId32 instead of %li.
Some MCUs have a different meaning for long int which causes compilation failure, most notably the ESP32.

## Testing Procedure
compile any RF test for the `esp32-wroom-32` board.