### PR TITLE
dist/tools/ci: Fix script naming for print env

### DIFF
--- a/dist/tools/ci/print_environment.sh
+++ b/dist/tools/ci/print_environment.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
-python3 $SCRIPTPATH/print_python_versions.py
+python3 $SCRIPTPATH/print_environment.py
 bash $SCRIPTPATH/../../../RIOT/dist/tools/ci/print_toolchain_versions.sh


### PR DESCRIPTION
Fixes the script name from `print_python_versions` to `print_environment`.

Test by calling `print_environment.sh`