### PR TITLE
fix(periph_timer): Fix casting issues in periph timer

### DIFF
--- a/tests/periph_timer/main.c
+++ b/tests/periph_timer/main.c
@@ -22,6 +22,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <string.h>
+#include <stdbool.h>
 
 #include "shell.h"
 #include "periph/timer.h"
@@ -275,8 +276,8 @@ int cmd_timer_debug_pin(int argc, char **argv)
 
     /* parse and init debug pin */
     uint32_t port, pin = 0;
-    if ((sc_arg2ulong(argv[2], &port) != ARGS_OK) ||
-        (sc_arg2ulong(argv[3], &pin) != ARGS_OK)) {
+    if ((sc_arg2u32(argv[2], &port) != ARGS_OK) ||
+        (sc_arg2u32(argv[3], &pin) != ARGS_OK)) {
         return _print_cmd_result("timer_debug_pin", false, 1, false);
     }
 


### PR DESCRIPTION
## Description

The esp32* seems to have some issues with bool type and what an unsigned long is.
Since bool types are being used, the stdbool is included.
Also since the port and pin type are defined as uint32_t, the call should be specifically for uint32_t.

## Testing Procedure
`BOARD=esp32-wroom-32 make all -C tests/periph_timer`

It will fail in master and this PR fixes it.