### PR TITLE
tests/periph_timer: Fix arg check of some timer calls

### DIFF
--- a/tests/periph_timer/main.c
+++ b/tests/periph_timer/main.c
@@ -197,7 +197,7 @@ int cmd_timer_set_absolute(int argc, char **argv)
 
 int cmd_timer_clear(int argc, char **argv)
 {
-    if (sc_args_check(argc, argv, 3, 3, "DEV CHANNEL TICKS") != ARGS_OK) {
+    if (sc_args_check(argc, argv, 2, 2, "DEV CHANNEL") != ARGS_OK) {
         return ARGS_ERROR;
     }
 
@@ -218,7 +218,7 @@ int cmd_timer_clear(int argc, char **argv)
 
 int cmd_timer_read(int argc, char **argv)
 {
-    if (sc_args_check(argc, argv, 3, 3, "DEV CHANNEL TICKS") != ARGS_OK) {
+    if (sc_args_check(argc, argv, 1, 1, "DEV") != ARGS_OK) {
         return ARGS_ERROR;
     }
 
@@ -233,7 +233,7 @@ int cmd_timer_read(int argc, char **argv)
 
 int cmd_timer_start(int argc, char **argv)
 {
-    if (sc_args_check(argc, argv, 3, 3, "DEV CHANNEL TICKS") != ARGS_OK) {
+    if (sc_args_check(argc, argv, 1, 1, "DEV") != ARGS_OK) {
         return ARGS_ERROR;
     }
 
@@ -248,7 +248,7 @@ int cmd_timer_start(int argc, char **argv)
 
 int cmd_timer_stop(int argc, char **argv)
 {
-    if (sc_args_check(argc, argv, 3, 3, "DEV CHANNEL TICKS") != ARGS_OK) {
+    if (sc_args_check(argc, argv, 1, 1, "DEV") != ARGS_OK) {
         return ARGS_ERROR;
     }
 


### PR DESCRIPTION
It seems some copy pasta issues with the `tests/periph_timer/main.c` file where it expects more arguments that is needed.

This PR fixes the argument checks for `cmd_timer_clear`, `cmd_timer_read`, `cmd_timer_start`, and `cmd_timer_stop`.

Let the CI test this one!