### PR TITLE
tests/timer:Fix gpio_init call in cmd_timer_debug_pin

### DIFF
--- a/tests/periph_timer/main.c
+++ b/tests/periph_timer/main.c
@@ -282,7 +282,7 @@ int cmd_timer_debug_pin(int argc, char **argv)
     }
 
     debug_pins[dev] = GPIO_PIN(port, pin);
-    gpio_init(pin, GPIO_OUT);
+    gpio_init(debug_pins[dev], GPIO_OUT);
 
     return _print_cmd_result("timer_debug_pin", true, 0, false);
 }


### PR DESCRIPTION
It seems like the gpio pin is only taking the pin and not the proper `GPIO(PORT, PIN)`.

This fixes it.

## Testing Procedure
Check to see if the CI is fixed.  The `nucleo-f103rb` is one board that suffers from this problem.