### PR TITLE
periph_i2c: Adapt i2c test to support read register

### DIFF
--- a/tests/periph_i2c/tests/04__periph_i2c_flags.robot
+++ b/tests/periph_i2c/tests/04__periph_i2c_flags.robot
@@ -30,15 +30,15 @@ Repeated Start Read Bytes 0 Should Succeed
     [Documentation]                         Verify DUT does not lockup on repeated start read
     PHiLIP.write reg                        user_reg  0
     API Call Should Succeed                 I2C Read Bytes  leng=2  flag=${I2C_FLAG_NOSTOP}
-    API Call Should Error                   I2C Read Bytes  leng=2
-    API Call Should Succeed                 I2C Read Bytes  leng=2  flag=${I2C_FLAG_NOSTART}
+    API Call Should Succeed                 I2C Read Bytes  leng=2
+    API Call Should Succeed                 I2C Read Bytes  leng=2
 
 Repeated Start Read Bytes 0xFF Should Succeed
     [Documentation]                         Verify DUT does not lockup on repeated start read
     PHiLIP.write reg                        user_reg  255
     API Call Should Succeed                 I2C Read Bytes  leng=2  flag=${I2C_FLAG_NOSTOP}
-    API Call Should Error                   I2C Read Bytes  leng=2
-    API Call Should Succeed                 I2C Read Bytes  leng=2  flag=${I2C_FLAG_NOSTART}
+    API Call Should Succeed                 I2C Read Bytes  leng=2
+    API Call Should Succeed                 I2C Read Bytes  leng=2
 
 Read Bytes By Frame Should Succeed
     [Documentation]                         Read bytes frame by frame


### PR DESCRIPTION
As mentioned in #53 the logic should reset when a start bit is sent.
This means that proper repeated read registers should be supported.

This changes the test to expect the repeated read success instead of saying not supported.

## Testing Procedure
Check the CI, investigate if any lockup occurs and if it does occur what is causing it.