### PR TITLE
periph_i2c: Add test for checking lines after release

### DIFF
--- a/tests/periph_i2c/tests/01__periph_i2c_base.robot
+++ b/tests/periph_i2c/tests/01__periph_i2c_base.robot
@@ -44,3 +44,12 @@ Read Byte After Multiple NACKs Should Succeed
     API Call Should Error       I2C Read Byte  addr=43
     API Call Should Succeed     I2C Read Byte
     API Call Should Succeed     I2C Release
+
+Pins High After Release Should Succeed
+    [Documentation]             Verify pins are high after release.
+    API Call Should Succeed     I2C Acquire
+    API Call Should Succeed     I2C Release
+    API Call Should Succeed     PHiLIP.read reg  i2c.dut_sda.level
+    Should Be Equal             ${RESULT['data']}  ${1}
+    API Call Should Succeed     PHiLIP.read reg  i2c.dut_scl.level
+    Should Be Equal             ${RESULT['data']}  ${1}


### PR DESCRIPTION
Add a test in response to https://github.com/RIOT-OS/RIOT/issues/10269

This adds a test the acquires and releases then checks the SDA and SCL lines.

Just check the CI