### PR TITLE
Jenkinsfile: Pipeline improvements to speed up source code checkout

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,10 +28,10 @@ def stepClone()
     }
     if ("${params.HIL_RIOT_VERSION}" == 'master') {
         // checkout latest RIOT master
-        sh 'git submodule update --init --remote --rebase'
+        sh 'git submodule update --init --remote --rebase --depth 1'
     }
     else {
-        sh 'git submodule update --init'
+        sh 'git submodule update --init --depth 1'
         if ("${params.HIL_RIOT_VERSION}" == 'pull' && "${params.HIL_RIOT_PULL}" != '0') {
             // checkout specified PR number
             def prnum = params.HIL_RIOT_PULL.toInteger()


### PR DESCRIPTION
This PR experimentally adds `--depth 1` to the `git submodule update`. The objective is to reduce the network overhead that comes with downloading the huge history of the RIOT submodule.

Let's observe this first, before merging.

EDIT: I added another commit that replaces the github interaction for each executor with a proper stash/unstash. The master node is now performing the initial `git clone` and scm setup, stashes the working dir, and all executors unstash the working directory.