### PR TITLE
robot: differentiate non-critical tests in xUnit results

### DIFF
--- a/dist/robotframework/Makefile.include
+++ b/dist/robotframework/Makefile.include
@@ -19,6 +19,7 @@ $(RFOUTPATH)/output.xml: $(ROBOT_FILES)
 				-o $@ \
 				-r NONE \
 				--xunit $(RFOUTPATH)/xunit.xml \
+				--xunitskipnoncritical \
 				$^
 
 # RF make targets


### PR DESCRIPTION
This PR adds an option to the `robot.run` command to differentiate critical and non-critical tests in xUnit results.

Refer last paragraph: https://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#id747