### PR TITLE
periph_spi: Add extension of SPI tests

### DIFF
--- a/tests/periph_spi/main.c
+++ b/tests/periph_spi/main.c
@@ -59,7 +59,7 @@ static struct {
     spi_cs_t cs;
 } spiconf;
 
-char printbuf[64] = {0};
+char printbuf[SHELL_DEFAULT_BUFSIZE] = {0};
 uint8_t in_buf[64];
 uint8_t out_buf[64];
 
@@ -334,7 +334,7 @@ int cmd_spi_transfer_regs(int argc, char **argv)
         len = in_len;
     }
     else {
-        len = 6 - argc;
+        len = argc - 6;
         out = out_buf;
         for (unsigned int i = 0; i < len; i++) {
             CHECK_ASSERT(sc_arg2u8(argv[6 + i], &out[i]) == ARGS_OK, "Could not parse OUT bytes");
@@ -344,7 +344,7 @@ int cmd_spi_transfer_regs(int argc, char **argv)
     sprintf(printbuf + offset, "in=%s len=%u", in_len ? "data" : "NULL", len);
 
     print_cmd(PARSER_DEV_NUM, printbuf);
-    spi_transfer_regs(dev, GPIO_PIN(port, pin), reg, in, out, len);
+    spi_transfer_regs(dev, GPIO_PIN(port, pin), reg, out, in, len);
 
     if (in != NULL) {
         for (unsigned int i = 0; i < len; i++) {

--- a/tests/periph_spi/tests/01__periph_spi_base.robot
+++ b/tests/periph_spi/tests/01__periph_spi_base.robot
@@ -29,8 +29,7 @@ Acquire after Release Should Succeed
     SPI Release Should Succeed
     SPI Acquire Should Succeed  0  100k
 
-Read Bytes Should Match
-    [Documentation]             Match bytes from board.
+Double Acquire Should Timeout
+    [Documentation]             Verify that acquiring a locked SPI bus blocks.
     SPI Acquire Should Succeed  0  100k
-    SPI Transfer Bytes Should Succeed  cont=0  in_len=5
-    Should Be Equal             ${RESULT['data']}  ${VAL_1}
+    SPI Acquire Should Timeout  0  100k

--- a/tests/periph_spi/tests/02__periph_spi_transfer.robot
+++ b/tests/periph_spi/tests/02__periph_spi_transfer.robot
@@ -1,0 +1,66 @@
+*** Settings ***
+Documentation       Verify functionality of transfering bytes and regs of the periph SPI API.
+
+Suite Setup         Run Keywords    PHILIP Reset
+...                                 RIOT Reset
+...                                 API Sync Shell
+...                                 API Firmware Should Match
+Test Setup          Run Keywords    PHILIP Reset
+...                                 RIOT Reset
+...                                 API Sync Shell
+...                                 SPI Init Should Succeed
+Test Teardown       Run Keywords    SPI Release Should Succeed
+
+Resource            periph_spi.keywords.txt
+Resource            api_shell.keywords.txt
+
+Variables           test_vars.py
+
+Force Tags          periph  spi
+
+
+*** Test Cases ***
+
+Transfer Single Bytes Should Succeed
+    [Documentation]  Sends a single byte two times using the spi_transfer_byte function.
+    ...              Once with the continue parameter and once without.
+    SPI Acquire Should Succeed          0  100k
+    SPI Transfer Byte Should Succeed   cont=1   out=41
+    Should Be Equal                     ${RESULT['data']}   ${VAL_1}
+    SPI Transfer Byte Should Succeed   cont=0   out=1
+    Should Be Equal                     ${RESULT['data']}   ${VAL_2}
+
+
+Transfer Multiple Bytes Should Succeed
+    [Documentation]  Sends 1, 2 and 16 bytes using the spi_transfer_bytes function.
+    ...              Uses multiple settings of the function parameters:
+    ...              cont is set and not set
+    ...              out has 1, 16 and none values
+    SPI Acquire Should Succeed          0  100k
+    SPI Transfer Bytes Should Succeed   cont=1   in_len=1   out=41
+    Should Be Equal                     ${RESULT['data']}   ${VAL_1}
+    SPI Transfer Bytes Should Succeed   cont=0   in_len=2
+    Should Be Equal                     ${RESULT['data']}   ${VAL_3}
+    SPI Transfer Bytes Should Succeed   cont=0   in_len=16  out=${VAL_4}
+    Should Be Equal                     ${RESULT['data']}   ${VAL_5}
+
+
+Transfer Single Reg Should Succeed
+    [Documentation]  Send a byte to a given register and reads it back using the
+    ...              spi_transfer_reg function
+    SPI Acquire Should Succeed          0  100k
+    SPI Transfer Reg Should Succeed     reg=41   out=5
+    Should Be Equal                     ${RESULT['data']}   ${VAL_2}
+    SPI Transfer Reg Should Succeed     reg=41   out=0
+    Should Be Equal                     ${RESULT['data']}   ${VAL_6}
+
+Transfer Multiple Regs Should Succeed
+    [Documentation]  Sends 1, 2 and 16 bytes strarting from a given register
+    ...              using the spi_transfer_regs function
+    SPI Acquire Should Succeed          0  100k
+    SPI Transfer Regs Should Succeed    reg=41   in_len=1   out=5
+    Should Be Equal                     ${RESULT['data']}   ${VAL_2}
+    SPI Transfer Regs Should Succeed    reg=42   in_len=2   out=6 7
+    Should Be Equal                     ${RESULT['data']}   ${VAL_7}
+    SPI Transfer Regs Should Succeed    reg=41   in_len=16  out=${VAL_4}
+    Should Be Equal                     ${RESULT['data']}   ${VAL_8}

--- a/tests/periph_spi/tests/03__periph_spi_modes.robot
+++ b/tests/periph_spi/tests/03__periph_spi_modes.robot
@@ -1,0 +1,64 @@
+*** Settings ***
+Documentation       Verify functionality of all 4 modes of the periph SPI API.
+
+Suite Setup         Run Keywords    PHILIP Reset
+...                                 RIOT Reset
+...                                 API Sync Shell
+...                                 API Firmware Should Match
+Test Setup          Run Keywords    PHILIP Reset
+...                                 RIOT Reset
+...                                 API Sync Shell
+...                                 SPI Init Should Succeed
+Test Teardown       Run Keywords    SPI Release Should Succeed
+
+Resource            periph_spi.keywords.txt
+Resource            api_shell.keywords.txt
+
+Variables           test_vars.py
+
+Force Tags          periph  spi
+
+*** Variables ***
+${hw_update_time}   0.1
+
+
+*** Keywords ***
+SPI Modes Transfer Bytes Should Succeed
+    [Documentation]     Initializes the SPI on both sides to the given mode
+    ...                 sends bytes and reads them back.
+    [Arguments]         ${mode}  ${cpol}  ${cpha}
+    API Call Should Succeed            PHiLIP.Write Reg       spi.mode.cpol    ${cpol}
+    API Call Should Succeed            PHiLIP.Write Reg       spi.mode.cpha    ${cpha}
+    API Call Should Succeed            PHiLIP.Write Reg       spi.mode.init       0
+    API Call Should Succeed            PHiLIP.Execute Changes
+    Sleep                              ${hw_update_time}
+
+    SPI Acquire Should Succeed         ${mode}             100k
+    SPI Transfer Bytes Should Succeed  cont=0              in_len=5   out=7 11 2 14 5
+    Should Be Equal                    ${RESULT['data']}   ${VAL_9}
+    SPI Transfer Bytes Should Succeed  cont=0              in_len=5   out=7 1 2 3 4
+    Should Be Equal                    ${RESULT['data']}   ${VAL_10}
+
+
+*** Test Cases ***
+Transfer Bytes Mode 0 Should Succeed
+    [Documentation]   Transfers Bytes in SPI mode 0 (cpol=0 and cpha=0)
+    SPI Modes Transfer Bytes Should Succeed    0  0  0
+
+
+Transfer Bytes Mode 1 Should Succeed
+    [Documentation]   Transfers Bytes in SPI mode 1 (cpol=0 and cpha=1)
+    SPI Modes Transfer Bytes Should Succeed    1  0  1
+
+
+Transfer Bytes Mode 2 Should Succeed
+    [Documentation]   Transfers Bytes in SPI mode 2 (cpol=1 and cpha=0)
+    SPI Modes Transfer Bytes Should Succeed    2  1  0
+
+
+Transfer Bytes Mode 3 Should Succeed
+    [Documentation]   Transfers Bytes in SPI mode 3 (cpol=1 and cpha=1)
+    SPI Modes Transfer Bytes Should Succeed    3  1  1
+
+
+

--- a/tests/periph_spi/tests/periph_spi.keywords.txt
+++ b/tests/periph_spi/tests/periph_spi.keywords.txt
@@ -16,6 +16,11 @@ SPI Acquire Should Succeed
     [Arguments]                 @{args}  &{kwargs}
     API Call Should Succeed     Spi acquire     %{HIL_SPI_DEV}  %{HIL_DUT_NSS_PORT}  %{HIL_DUT_NSS_PIN}  @{args}  &{kwargs}
 
+SPI Acquire Should Timeout
+    [Documentation]             Acquire SPI with default parameters
+    [Arguments]                 @{args}  &{kwargs}
+    API Call Should Timeout     Spi acquire     %{HIL_SPI_DEV}  %{HIL_DUT_NSS_PORT}  %{HIL_DUT_NSS_PIN}  @{args}  &{kwargs}
+
 SPI Release Should Succeed
     [Documentation]             Release SPI with default parameters
     API Call Should Succeed     Spi release     %{HIL_SPI_DEV}
@@ -24,3 +29,18 @@ SPI Transfer Bytes Should Succeed
     [Arguments]                 @{args}  &{kwargs}
     [Documentation]             Transfer SPI bytes with default parameters should succeed
     API Call Should Succeed     Spi transfer bytes  %{HIL_SPI_DEV}  %{HIL_DUT_NSS_PORT}  %{HIL_DUT_NSS_PIN}  @{args}  &{kwargs}
+
+SPI Transfer Byte Should Succeed
+    [Arguments]                 @{args}  &{kwargs}
+    [Documentation]             Transfer SPI byte with default parameters should succeed
+    API Call Should Succeed     Spi transfer byte  %{HIL_SPI_DEV}  %{HIL_DUT_NSS_PORT}  %{HIL_DUT_NSS_PIN}  @{args}  &{kwargs}
+
+SPI Transfer Reg Should Succeed
+    [Arguments]                 @{args}  &{kwargs}
+    [Documentation]             Transfer SPI reg with default parameters should succeed
+    API Call Should Succeed     Spi transfer reg  %{HIL_SPI_DEV}  %{HIL_DUT_NSS_PORT}  %{HIL_DUT_NSS_PIN}  @{args}  &{kwargs}
+
+SPI Transfer Regs Should Succeed
+    [Arguments]                 @{args}  &{kwargs}
+    [Documentation]             Transfer SPI regs with default parameters should succeed
+    API Call Should Succeed     Spi transfer regs  %{HIL_SPI_DEV}  %{HIL_DUT_NSS_PORT}  %{HIL_DUT_NSS_PIN}  @{args}  &{kwargs}

--- a/tests/periph_spi/tests/periph_spi_if.py
+++ b/tests/periph_spi/tests/periph_spi_if.py
@@ -4,7 +4,7 @@
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 """@package PyToAPI
-This module handles parsing of information from RIOT periph_i2c test.
+This module handles parsing of information from RIOT periph_spi test.
 """
 import logging
 
@@ -40,7 +40,7 @@ class PeriphSpiIf(DutShell):
 
     def spi_transfer_byte(self, dev, port, pin, cont, out):
         """Transfer one byte on the given SPI bus"""
-        return self.send_cmd('spi_transfer_byte {} {} {} {}'.format(dev, port, pin, cont, out))
+        return self.send_cmd('spi_transfer_byte {} {} {} {} {}'.format(dev, port, pin, cont, out))
 
     def spi_transfer_bytes(self, dev, port, pin, cont, in_len, out=None):
         """Transfer a number bytes using the given SPI bus"""
@@ -60,8 +60,8 @@ class PeriphSpiIf(DutShell):
         else:
             return self.send_cmd('spi_transfer_regs {} {} {} {} {}'.format(dev, port, pin, reg, in_len))
 
-    def i2c_get_devs(self):
-        """Gets amount of supported i2c devices."""
+    def spi_get_devs(self):
+        """Gets amount of supported spi devices."""
         return self.send_cmd('spi_get_devs')
 
     def get_metadata(self):

--- a/tests/periph_spi/tests/test_vars.py
+++ b/tests/periph_spi/tests/test_vars.py
@@ -14,3 +14,6 @@ LIST__VAL_5 = [254] + list(range(3, 16 + 3 - 1))
 LIST__VAL_6 = [5]
 LIST__VAL_7 = [42, 43]
 LIST__VAL_8 = [5, 6, 7] + list(range(44, 16 + 44 - 3))
+
+LIST__VAL_9 = [254, 7, 8, 9, 10]
+LIST__VAL_10 = [254, 11, 2, 14, 5]

--- a/tests/periph_spi/tests/test_vars.py
+++ b/tests/periph_spi/tests/test_vars.py
@@ -1,1 +1,16 @@
-LIST__VAL_1 = [254, 0, 1, 2, 3]
+def str_4():
+	result = ""
+	for i in range(3, 16 + 3):
+	    result += str(i) + " "
+	return result
+
+LIST__VAL_1 = [254]
+LIST__VAL_2 = [41]
+LIST__VAL_3 = [41, 42]
+
+VAL_4 = str_4()
+LIST__VAL_5 = [254] + list(range(3, 16 + 3 - 1))
+
+LIST__VAL_6 = [5]
+LIST__VAL_7 = [42, 43]
+LIST__VAL_8 = [5, 6, 7] + list(range(44, 16 + 44 - 3))


### PR DESCRIPTION
This PR fixes some bugs in the interface and the main program of the SPI and extends the tests as follows:

- All 4 modes (different variations of the clk phase and clk polarity) are tested now.
- The transfer of bytes is tested with all possible functions of the interface
- A test for double acquiring the SPI bus. 

This was tested with the boards:
- nucleo-l073rz
- nucleo-f303re
- nucleo-l152re

and nucleo-f103rb as PHiLIP-board.