### PR TITLE
api_shell: Fix FOR warning

### DIFF
--- a/dist/robotframework/res/api_shell.keywords.txt
+++ b/dist/robotframework/res/api_shell.keywords.txt
@@ -56,9 +56,10 @@ API Result Data Should Not Contain
 API Call Repeat on Timeout
     [Documentation]     Repeats the given API ``call`` up to 5 times on timeout.
     [Arguments]         ${call}  @{args}  &{kwargs}
-    :FOR    ${i}    IN RANGE  0  16
-    \   Run Keyword And Ignore Error  API Call Should Timeout  ${call}  @{args}  &{kwargs}
-    \   Run Keyword If  "${RESULT['result']}"!="Timeout"  Exit For Loop
+    FOR    ${i}    IN RANGE  0  16
+        Run Keyword And Ignore Error  API Call Should Timeout  ${call}  @{args}  &{kwargs}
+        Run Keyword If  "${RESULT['result']}"!="Timeout"  Exit For Loop
+    END
     Should Contain      ${RESULT['result']}   Success
 
 API Firmware Should Match


### PR DESCRIPTION
It seems like updating robot has some deprecation issues.
The warning  appears `Error in file '/opt/jenkins/workspace/RIOT-HIL_nightly/dist/robotframework/res/api_shell.keywords.txt' in FOR loop starting on line 59: For loop header ':FOR' is deprecated. Use 'FOR' instead.`
This fixes that by using `FOR` instead of `:FOR`.