### PR TITLE
tests/periph_gpio: Add IC and PWM to gpio test

### DIFF
--- a/tests/periph_gpio/tests/02__periph_gpio_others.robot
+++ b/tests/periph_gpio/tests/02__periph_gpio_others.robot
@@ -29,3 +29,5 @@ Verify SPI_MOSI     spi             dut_mosi        %{HIL_DUT_MOSI_PORT}    %{HI
 Verify I2C_SCL      i2c             dut_scl         %{HIL_DUT_SCL_PORT}     %{HIL_DUT_SCL_PIN}
 Verify I2C_SDA      i2c             dut_sda         %{HIL_DUT_SDA_PORT}     %{HIL_DUT_SDA_PIN}
 Verify ADC          adc             dut_adc         %{HIL_DUT_ADC_PORT}     %{HIL_DUT_ADC_PIN}
+Verify PWM          pwm             dut_pwm         %{HIL_DUT_PWM_PORT}     %{HIL_DUT_PWM_PIN}
+Verify IC           tmr             dut_ic          %{HIL_DUT_IC_PORT}      %{HIL_DUT_IC_PIN}


### PR DESCRIPTION
Now that the environment for the PWM and IC pins are defined we should start testing to make sure they are connected.

This should be verified in the CI. At least a few boards should have this functioning (the ones that don't need to be rewired).