### PR TITLE
tests/periph_spi: Add tests for clock speed

### DIFF
--- a/tests/periph_spi/main.c
+++ b/tests/periph_spi/main.c
@@ -156,16 +156,16 @@ int cmd_spi_acquire(int argc, char **argv)
     if (strcmp(argv[3], "100k") == 0) {
         spiconf.clk = SPI_CLK_100KHZ;
     }
-    else if (strcmp(argv[3], "100k") == 0) {
+    else if (strcmp(argv[3], "400k") == 0) {
         spiconf.clk = SPI_CLK_400KHZ;
     }
-    else if (strcmp(argv[3], "400k") == 0) {
+    else if (strcmp(argv[3], "1M") == 0) {
         spiconf.clk = SPI_CLK_1MHZ;
     }
-    else if (strcmp(argv[3], "1M") == 0) {
+    else if (strcmp(argv[3], "5M") == 0) {
         spiconf.clk = SPI_CLK_5MHZ;
     }
-    else if (strcmp(argv[3], "5M") == 0) {
+    else if (strcmp(argv[3], "10M") == 0) {
         spiconf.clk = SPI_CLK_10MHZ;
     }
     else {

--- a/tests/periph_spi/tests/04__periph_spi_timer.robot
+++ b/tests/periph_spi/tests/04__periph_spi_timer.robot
@@ -1,0 +1,60 @@
+*** Settings ***
+Documentation       Verify that the meassured times are within a certain window
+
+Suite Setup         Run Keywords    PHILIP Reset
+...                                 RIOT Reset
+...                                 API Sync Shell
+...                                 API Firmware Should Match
+Test Setup          Run Keywords    PHILIP Reset
+...                                 RIOT Reset
+...                                 API Sync Shell
+...                                 SPI Init Should Succeed
+Test Teardown       Run Keywords    SPI Release Should Succeed
+
+Resource            periph_spi.keywords.txt
+Resource            api_shell.keywords.txt
+
+Variables           test_vars.py
+
+Force Tags          periph  spi
+
+
+*** Keywords ***
+SPI Clock Speed Check
+    [Documentation]     Main routine to verify the clock speed
+    [Arguments]         ${clk_speed_string}  ${clk_speed_value}  ${size}
+    API Call Should Succeed             PHiLIP.Write Reg        spi.mode.if_type    3
+    API Call Should Succeed             PHiLIP.Write Reg        spi.mode.init       0
+    API Call Should Succeed             PHiLIP.Execute Changes
+    SPI Acquire Should Succeed          0  ${clk_speed_string}
+    SPI Transfer Bytes Should Succeed   cont=0   in_len=${size}
+    API Call Should Succeed             PHiLIP.Read Reg         sys.sys_clk
+    ${sys_clk} =  Set Variable          ${RESULT['data']}
+    API Call Should Succeed             PHiLIP.Read Reg         spi.frame_ticks
+    ${spi_speed_limits} =  Set Variable  
+    ...  ${spi_speed_limits(${clk_speed_value}, ${sys_clk}, ${size})}
+    Should Be True  
+    ...  ${spi_speed_limits}[0] < ${RESULT['data']} and ${spi_speed_limits}[1] > ${RESULT['data']}
+    ...  Number of ticks should be between ${spi_speed_limits}[0] and ${spi_speed_limits}[1] but was ${RESULT['data']}
+
+
+*** Test Cases ***
+Clock Speed 100k Should Succeed
+    [Documentation]  Checks the clock speed for 100kHz
+    SPI Clock Speed Check    100k     100000    8
+
+Clock Speed 400k Should Succeed
+    [Documentation]  Checks the clock speed for 400kHz
+    SPI Clock Speed Check    400k     400000    8
+
+Clock Speed 1M Should Succeed
+    [Documentation]  Checks the clock speed for 1MHz
+    SPI Clock Speed Check      1M    1000000    8
+
+Clock Speed 5M Should Succeed
+    [Documentation]  Checks the clock speed for 5MHz
+    SPI Clock Speed Check      5M    5000000    8
+
+Clock Speed 10M Should Succeed
+    [Documentation]  Checks the clock speed for 10MHz
+    SPI Clock Speed Check     10M   10000000    8

--- a/tests/periph_spi/tests/04__periph_spi_timer.robot
+++ b/tests/periph_spi/tests/04__periph_spi_timer.robot
@@ -23,38 +23,56 @@ Force Tags          periph  spi
 SPI Clock Speed Check
     [Documentation]     Main routine to verify the clock speed
     [Arguments]         ${clk_speed_string}  ${clk_speed_value}  ${size}
-    API Call Should Succeed             PHiLIP.Write Reg        spi.mode.if_type    3
-    API Call Should Succeed             PHiLIP.Write Reg        spi.mode.init       0
-    API Call Should Succeed             PHiLIP.Execute Changes
+    PHiLIP.write and execute            spi.mode.if_type    3
     SPI Acquire Should Succeed          0  ${clk_speed_string}
     SPI Transfer Bytes Should Succeed   cont=0   in_len=${size}
     API Call Should Succeed             PHiLIP.Read Reg         sys.sys_clk
     ${sys_clk} =  Set Variable          ${RESULT['data']}
-    API Call Should Succeed             PHiLIP.Read Reg         spi.frame_ticks
+    API Call Should Succeed             PHiLIP.Read Reg         spi.byte_ticks
     ${spi_speed_limits} =  Set Variable  
     ...  ${spi_speed_limits(${clk_speed_value}, ${sys_clk}, ${size})}
     Should Be True  
-    ...  ${spi_speed_limits}[0] < ${RESULT['data']} and ${spi_speed_limits}[1] > ${RESULT['data']}
-    ...  Number of ticks should be between ${spi_speed_limits}[0] and ${spi_speed_limits}[1] but was ${RESULT['data']}
+    ...  ${spi_speed_limits}[0] < ${${RESULT['data']} * ${size}} and ${spi_speed_limits}[1] > ${${RESULT['data']} * ${size}}
+    ...  Time should be between ${convert_ticks_to_us(${spi_speed_limits[0]},${sys_clk})}us and ${convert_ticks_to_us(${spi_speed_limits[1]},${sys_clk})}us but was ${convert_ticks_to_us(${RESULT['data']} * ${size}, ${sys_clk})}us
 
 
 *** Test Cases ***
 Clock Speed 100k Should Succeed
     [Documentation]  Checks the clock speed for 100kHz
+    SPI Clock Speed Check    100k     100000    1
+
+Clock Speed 100k Should Succeed 8 Byte
+    [Documentation]  Checks the clock speed for 100kHz
     SPI Clock Speed Check    100k     100000    8
 
 Clock Speed 400k Should Succeed
+    [Documentation]  Checks the clock speed for 400kHz
+    SPI Clock Speed Check    400k     400000    1
+
+Clock Speed 400k Should Succeed 8 Byte
     [Documentation]  Checks the clock speed for 400kHz
     SPI Clock Speed Check    400k     400000    8
 
 Clock Speed 1M Should Succeed
     [Documentation]  Checks the clock speed for 1MHz
+    SPI Clock Speed Check      1M    1000000    1
+
+Clock Speed 1M Should Succeed 8 Byte
+    [Documentation]  Checks the clock speed for 1MHz
     SPI Clock Speed Check      1M    1000000    8
 
 Clock Speed 5M Should Succeed
     [Documentation]  Checks the clock speed for 5MHz
+    SPI Clock Speed Check      5M    5000000    1
+
+Clock Speed 5M Should Succeed 8 Byte
+    [Documentation]  Checks the clock speed for 5MHz
     SPI Clock Speed Check      5M    5000000    8
 
 Clock Speed 10M Should Succeed
+    [Documentation]  Checks the clock speed for 10MHz
+    SPI Clock Speed Check     10M   10000000    1
+
+Clock Speed 10M Should Succeed 8 Byte
     [Documentation]  Checks the clock speed for 10MHz
     SPI Clock Speed Check     10M   10000000    8

--- a/tests/periph_spi/tests/test_vars.py
+++ b/tests/periph_spi/tests/test_vars.py
@@ -20,9 +20,24 @@ LIST__VAL_10 = [254, 11, 2, 14, 5]
 
 
 def spi_speed_limits(spi_speed, sys_clock_speed, bytes):
-	expected_byte_ticks = round(8 / spi_speed * sys_clock_speed)
-	expected_frame_ticks = expected_byte_ticks * bytes
-	error_tol = round(expected_byte_ticks + expected_byte_ticks * bytes / 8)
-	lower_limit = expected_frame_ticks - error_tol
-	upper_limit = expected_frame_ticks + error_tol
+
+	for i in range(2):
+		if i == 0:
+			spi_speed_limit = spi_speed * 1.20
+		else:
+			spi_speed_limit = spi_speed * 0.8
+
+		expected_byte_ticks = round((8 * sys_clock_speed) / spi_speed_limit)
+		expected_frame_ticks = expected_byte_ticks * bytes
+		error_tol = round(expected_byte_ticks * bytes / 8)
+
+		if i == 0:
+			lower_limit = expected_frame_ticks - error_tol
+		else:
+			upper_limit = expected_frame_ticks + error_tol
+
 	return [lower_limit, upper_limit]
+
+
+def convert_ticks_to_us(ticks, sys_clock_speed):
+	return round(ticks / sys_clock_speed * 1000000, 3)

--- a/tests/periph_spi/tests/test_vars.py
+++ b/tests/periph_spi/tests/test_vars.py
@@ -17,3 +17,12 @@ LIST__VAL_8 = [5, 6, 7] + list(range(44, 16 + 44 - 3))
 
 LIST__VAL_9 = [254, 7, 8, 9, 10]
 LIST__VAL_10 = [254, 11, 2, 14, 5]
+
+
+def spi_speed_limits(spi_speed, sys_clock_speed, bytes):
+	expected_byte_ticks = round(8 / spi_speed * sys_clock_speed)
+	expected_frame_ticks = expected_byte_ticks * bytes
+	error_tol = round(expected_byte_ticks + expected_byte_ticks * bytes / 8)
+	lower_limit = expected_frame_ticks - error_tol
+	upper_limit = expected_frame_ticks + error_tol
+	return [lower_limit, upper_limit]


### PR DESCRIPTION
This verifies the SPI Clock speed for the valid RIOT values of 100kHZ, 400kHz, 1MHz, 5MHz and 10MHz.
Also fixes a bug in the periph_spi main: the argument values were not mapped to the correct clock values.

Atleast for STM32 CPUs there are some problems with higher speeds and the transfer of multiple bytes since there is a pause with every byte. This is currently not calculated in the window and therefore the tranfer seems too slow.
For 10MHz and transfer ob Byte PHiLIP always gives 0 as spi.byte_ticks.