### PR TITLE
Add "Record Property" keyword

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ doc/doxygen/*.tmp
 # Built binaries
 *bin
 # Build directory
-/build
+build/
 # Backup files
 *~
 *.orig

--- a/dist/robotframework/res/util.keywords.txt
+++ b/dist/robotframework/res/util.keywords.txt
@@ -8,3 +8,9 @@ Length Should Be Greater
     [Arguments]         ${list}     ${gtlen}
     ${length}=          Get Length  ${list}
     Should be True      ${length} > ${gtlen}
+
+Record Property
+    [Documentation]     Adds the given property in output
+    [Arguments]         ${name}     ${value}
+    Log                 NAME: ${name}
+    Log                 VALUE: ${value}

--- a/dist/tools/output_to_xunit/README.md
+++ b/dist/tools/output_to_xunit/README.md
@@ -1,0 +1,24 @@
+# README
+
+Parses `output.xml` from a RobotFramework result to a xUnit style format. The parsing is done by the `output_to_xunit.py` script. Run `output_to_xunit.py -h` to get the usage info.
+
+## Testing
+
+```
+# Run tests and generate output.xml
+robot --outputdir build --pythonpath "test:../../robotframework/res/" --noncritical skip --noncritical warn-if-failed test/example_testsuite/
+
+# Parse output and generate xunit.xml in the current directory (default)
+python3 output_to_xunit.py build/output.xml
+
+# Specifying custom output directory/name
+python3 output_to_xunit.py --output build/test_xunit.xml build/output.xml
+```
+
+NOTE: `Test Failed Testcase` and `Test Fail Skipped Testcase` is supposed to fail.
+
+## Schema Validation
+
+TODO
+
+

--- a/dist/tools/output_to_xunit/output_to_xunit.py
+++ b/dist/tools/output_to_xunit/output_to_xunit.py
@@ -1,0 +1,125 @@
+#! /usr/bin/env python3
+import argparse
+import xml.etree.ElementTree as ET
+from datetime import datetime as DT
+
+
+TIME_FORMAT = "%Y%m%d %H:%M:%S.%f"
+XUNIT_OUT = "xunit.xml"
+
+args_parser = argparse.ArgumentParser(
+    description="Parse RobotFrameworks output.xml to xUnit format",
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+)
+args_parser.add_argument(
+    "--output",
+    type=str,
+    help="path to file where the output should be written to",
+    default=XUNIT_OUT,
+)
+args_parser.add_argument(
+    "input", type=str, help="path to a file in RobotFramework output format"
+)
+args = args_parser.parse_args()
+
+tree = ET.parse(args.input)
+root = tree.getroot()
+
+suite = root.find("suite")
+testsuite = {
+    "name": suite.get("name"),
+    "skipped": 0,
+    "failures": 0,
+    "errors": 0,
+}
+
+starttime = DT.strptime(suite.find("status").get("starttime"), TIME_FORMAT)
+endtime = DT.strptime(suite.find("status").get("endtime"), TIME_FORMAT)
+suitetime = str((endtime - starttime).total_seconds())
+testsuite["time"] = suitetime
+
+testcases = list()
+child_suites = suite.findall("suite")
+for suite in child_suites:
+    for test in suite.findall("test"):
+        testcase = {
+            "classname": f"{testsuite['name']}.{suite.get('name')}",
+            "name": test.get("name"),
+            "failed": False,
+            "skipped": False,
+        }
+
+        starttime = DT.strptime(test.find("status").get("starttime"), TIME_FORMAT)
+        endtime = DT.strptime(test.find("status").get("endtime"), TIME_FORMAT)
+        testtime = str((endtime - starttime).total_seconds())
+        testcase["time"] = testtime
+
+        # check if testcase failed
+        if test.find("status").get("status") == "FAIL":
+            testcase["failed"] = True
+            testcase["failed_text"] = test.find("status").text
+            testsuite["failures"] += 1
+
+        # check if testcase skipped
+        tags = [tag.text for tag in test.findall("tags/tag")]
+        if "skip" in tags:
+            testcase["skipped"] = True
+            testcase["skipped_text"] = test.find("status").get("status")
+            testsuite["skipped"] += 1
+
+        testcase["records"] = list()
+        for record in test.findall("kw[@name='Record Property']"):
+            r = dict()
+            for e in record.iter("msg"):
+                text = e.text
+                if text.startswith("NAME:"):
+                    r["name"] = text[len("NAME: ") :]
+                elif text.startswith("VALUE:"):
+                    r["value"] = text[len("VALUE: ") :]
+            testcase["records"].append(r)
+        testcases.append(testcase)
+
+stats = root.find("statistics/total")
+total_all = next(obj for obj in stats if obj.text == 'All Tests')
+total_critical = next(obj for obj in stats if obj.text == 'Critical Tests')
+testsuite["failures"] = total_critical.get("fail")
+testsuite["skipped"] = str(
+    int(total_all.get("fail")) - int(total_critical.get("fail"))
+)  # skipped is equivalent to non-critical fail
+testsuite["tests"] = str(int(total_all.get("pass")) + int(total_all.get("fail")))
+testsuite["errors"] = str(len(root.find("errors")))
+testsuite["testcases"] = testcases
+testsuite["tests"] = str(len(testsuite["testcases"]))
+
+# Parsing done, building the xunit output
+newroot = ET.Element("testsuite")
+newroot.set("name", testsuite["name"])
+newroot.set("tests", testsuite["tests"])
+newroot.set("errors", testsuite["errors"])
+newroot.set("failures", testsuite["failures"])
+newroot.set("skipped", testsuite["skipped"])
+newroot.set("time", testsuite["time"])
+
+for tc in testsuite["testcases"]:
+    testcase = ET.SubElement(newroot, "testcase")
+    testcase.set("classname", tc["classname"])
+    testcase.set("name", tc["name"])
+    testcase.set("time", tc["time"])
+
+    if tc["skipped"]:
+        skipped = testcase = ET.SubElement(testcase, "skipped")
+        skipped.text = tc["skipped_text"]
+    elif tc["failed"]:
+        failure = ET.SubElement(testcase, "failure")
+        failure.text = tc["failed_text"]
+
+
+    if len(tc["records"]) > 0:
+        properties = ET.SubElement(testcase, "properties")
+        for r in tc["records"]:
+            record = ET.SubElement(properties, "property")
+            record.set("name", r["name"])
+            record.set("value", r["value"])
+
+newtree = ET.ElementTree(newroot)
+newtree.write(args.output)

--- a/dist/tools/output_to_xunit/test/TestData.py
+++ b/dist/tools/output_to_xunit/test/TestData.py
@@ -1,0 +1,32 @@
+# Copyright (C) 2019 Kevin Weiss <kevin.weiss@haw-hamburg.de>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.z
+"""@package PyToAPI
+This module handles parsing of information from RIOT periph_gpio test.
+"""
+from riot_pal import DutShell
+from robot.api import logger
+from robot.version import get_version
+
+import random
+
+
+class TestData():
+    """Interface to the node."""
+
+    ROBOT_LIBRARY_SCOPE = "TEST"
+    ROBOT_LIBRARY_VERSION = get_version()
+
+    def get_empty(self):
+        return ""
+
+    def get_long_list(self):
+        return [i for i in range(0, 500)]
+
+    def get_long_dict(self):
+        return {f"{str(i)}": i**2 for i in range(0, 500)}
+
+    def get_long_string(self):
+        return ''.join(random.choices("HEYDSLKJSDFLKJD", k=1000))

--- a/dist/tools/output_to_xunit/test/example_testsuite/example_test.robot
+++ b/dist/tools/output_to_xunit/test/example_testsuite/example_test.robot
@@ -1,0 +1,33 @@
+*** Settings ***
+Library     TestData
+
+Resource    util.keywords.txt
+
+*** Keywords ***
+Call Library
+    [Arguments]         ${call}
+    ${RESULT}=          Run Keyword  ${call}
+    Set Suite Variable  ${RESULT}
+
+*** Test Cases ***
+Passed Testcase
+    Pass Execution  TEST PASSED
+Failed Testcase
+    Fail            TEST FAILED
+Pass Skipped Testcase
+    Set Tags        skip
+Fail Skipped Testcase
+    Set Tags  skip
+    Fail
+Record Empty value
+    Call Library        TestData.Get Empty
+    Record Property     LONG_STRING    ${RESULT}
+Record String value
+    Call Library        TestData.Get Long String
+    Record Property     LONG_STRING    ${RESULT}
+Record Long List
+    Call Library        TestData.Get Long List
+    Record Property     LONG_LIST      ${RESULT}
+Record Long Dict
+    Call Library        TestData.Get Long Dict
+    Record Property     LONG_DICT      ${RESULT}


### PR DESCRIPTION
This PR adds the keyword "Record Property" and also a parser script `output_to_xunit.py` parser script to parse the of RobotFrameworks `output.xml`. The parsed xUnit is same as the xUnit output of RF (`--xunit xunit.xm` and `--xunitskipnoncritical`), with the addition of `<properties>` tag to record the properties.

NOTE: The parser script is limited to handle only the current structure of testsuites/testcases. It may produce incorrect xUnit output when used on other `output.xml`.

To use the keyword, include `utils.keyword.txt` as a `Resource` in the `.robot` file. See `dist/tools/output_to_xunit/test/example_testsuite/example_test.robot` for example.