### PR TITLE
Use output xunit script

### DIFF
--- a/dist/robotframework/Makefile.include
+++ b/dist/robotframework/Makefile.include
@@ -1,7 +1,7 @@
 # RF specific paths
 RFBASE    ?= $(TESTBASE)/dist/robotframework
 RFPYPATH  ?= $(APPDIR)/tests:$(RFBASE)/lib:$(RFBASE)/res
-RFOUTPATH ?= $(BUILD_DIR)/robot/$(BOARD)/$(APPLICATION)/
+RFOUTPATH ?= $(BUILD_DIR)/robot/$(BOARD)/$(APPLICATION)
 # search for RF test script files
 ROBOT_FILES ?= $(sort $(wildcard tests/*.robot))
 
@@ -18,9 +18,10 @@ $(RFOUTPATH)/output.xml: $(ROBOT_FILES)
 				-l NONE \
 				-o $@ \
 				-r NONE \
-				--xunit $(RFOUTPATH)/xunit.xml \
-				--xunitskipnoncritical \
 				$^
+	python3 $(TESTBASE)/dist/tools/output_to_xunit/output_to_xunit.py \
+				--output $(RFOUTPATH)/xunit.xml \
+				$@
 
 # RF make targets
 robot-test: $(RFOUTPATH)/output.xml

--- a/dist/robotframework/Makefile.include
+++ b/dist/robotframework/Makefile.include
@@ -2,11 +2,10 @@
 RFBASE    ?= $(TESTBASE)/dist/robotframework
 RFPYPATH  ?= $(APPDIR)/tests:$(RFBASE)/lib:$(RFBASE)/res
 RFOUTPATH ?= $(BUILD_DIR)/robot/$(BOARD)/$(APPLICATION)
-# search for RF test script files
-ROBOT_FILES ?= $(sort $(wildcard tests/*.robot))
+ROBOT_TESTDIR ?= tests/
 
-$(RFOUTPATH)/output.xml: $(ROBOT_FILES)
-	python3 -m robot.run --noncritical skip \
+$(RFOUTPATH)/output.xml: $(ROBOT_TESTDIR)
+	-python3 -m robot.run --noncritical skip \
 				--name "$(APPLICATION)" \
 				--noncritical warn-if-failed \
 				--settag "APP_$(APPLICATION)" \

--- a/dist/tools/output_to_xunit/output_to_xunit.py
+++ b/dist/tools/output_to_xunit/output_to_xunit.py
@@ -68,7 +68,7 @@ for suite in child_suites:
             testsuite["skipped"] += 1
 
         testcase["records"] = list()
-        for record in test.findall("kw[@name='Record Property']"):
+        for record in test.findall(".//kw[@name='Record Property']"):
             r = dict()
             for e in record.iter("msg"):
                 text = e.text

--- a/dist/tools/output_to_xunit/test/example_testsuite/example_test.robot
+++ b/dist/tools/output_to_xunit/test/example_testsuite/example_test.robot
@@ -9,6 +9,10 @@ Call Library
     ${RESULT}=          Run Keyword  ${call}
     Set Suite Variable  ${RESULT}
 
+Predefined Keyword
+    Call Library        TestData.Get Long String
+    Record Property     LONG_STRING    ${RESULT}
+
 *** Test Cases ***
 Passed Testcase
     Pass Execution  TEST PASSED
@@ -31,3 +35,4 @@ Record Long List
 Record Long Dict
     Call Library        TestData.Get Long Dict
     Record Property     LONG_DICT      ${RESULT}
+Record using keyword    Predefined Keyword


### PR DESCRIPTION
This PR changes the build system to use the `output_to_xunit.py` script from #75. The script is also changed to detect Record Property tags in nested deeper in the output, making the parsing more robust. The `robot-test` command is modified to specify only the top directory of the RF tests e.g. (`tests/`) to make sure that the resulting `output.xml` maintains the directory structure that we defined.

# Testing

Run the instruction in the README. In the resulting `test_xunit.xml` a new testcase `Record using keyword` is added.

Expected:
```
<testcase classname="Example Testsuite.Example Test" name="Record using keyword" time="0.002">
    <properties>
        <property name="LONG_STRING" value="LSSDDDJDLJFLJSFDEJSYKLSLSDSKLSDEJFJKYDKJKJHYLDEFDDJDHSHESLDLJJFKKJFKLKDLJDJKEKJDLHSHSJKJKYLJDDDSEYHKSSSJYLDDKFDDKSDSKKDKDSDJFLKKEYDJSLSJKFSKLDLKJJKJEYJSDLKKKFSEEJKFJKSFDLHKDLSSJSSHDDYDSJKLSEYKKFLJFDKJSDFDEEDSSDLDDHHYHHLDJHKJDJSJDYLSSDLJDFYFDKSFSFKLKKHSSKFKJHJDSKSSJKYDSLKSDJHLYFKYJSDFLJKFDHFDDSHFLSDFSEFSDLSESJDLSLDYEJFEDHDJKKDKDSFLLKJKEJLSFEDJJSLDSKSLKKDJDKSHKDDJLJFDDSLHKHFKYJJJFLDLEEYJJYFHLJDKDKSJFDSEKDFJDDEDKYSHKJYDHJJLEKDLJSDSDJKDKSJSSJYKFDYYDLLYSEKLSEHDYFLKKJKKLSSFSSSSLLFDFFFESLYDDFYDYEYDLDDDFFJKESJDDLJKJJKHSJHHHSDSDDSDFDYSLLDJLELLJSDFSYYYEDDEDSLKLHDYSEDDDDFJDDYDSYHDLJJEJJLJHJDFYDDKDKLDEJKESKHDDJJJYFJKHHSLKLJYSDDDDDDLDKDDJKDDSLDJKHFKDSSDDLEFDEDJJLEDFDKLJJLDJSDSSFKLKLDSYDYLDYLYLHLEYEYJLJLYKYSDLJDJSYYJDEKDYHKHYDHHJEYFFFDHDDDSDJSFDSHSDDKJHFFDDDKLFYLDFDHDLEJSSHYDYFDKJKYLFLLLYSSSJDDSDJJJFJSKYSKLSHSLJHFYKDJDDDKDKKJHDHYJDSEFSKHSLJHEDJLYLJJSDLHLLSLDKLHKJYYYDHLDDFDKKDFDJKJJDKFSKEJHFHSLJKLFSKJSSJSKKYEJKSKKHSESEYSFHSESJSDKLSLSLSKFJDKJDSSYSJSDLKKSEEDSKKDFDLDSLJYEFLYDKDJDJLDHJFHKKSFKDYDFDSDKKSJS" /> 
    </properties>
</testcase>
```

Without https://github.com/RIOT-OS/RobotFW-tests/commit/121a52093fad99f77e897105c537bd4a1b7c3089, the output will not have any properties:

```
<testcase classname="Example Testsuite.Example Test" name="Record using keyword" time="0.002" />
```