### PR TITLE
fix(periph_uart): Make the missing uart modes skip and not pass

### DIFF
--- a/tests/periph_uart/tests/periph_uart.keywords.txt
+++ b/tests/periph_uart/tests/periph_uart.keywords.txt
@@ -36,7 +36,10 @@ UART Write Should Timeout
 UART Mode Should Exist
     [Documentation]             Verify DUT supports UART mode configuration
     ${status}   ${value}=       Run Keyword And Ignore Error   API Call Should Succeed   Uart Mode  %{HIL_UART_DEV}
-    Pass Execution If           '${status}'=='FAIL'   Feature is not supported
+    Run Keyword If              '${status}'=='FAIL'  UART Mode not supported
+
+UART Mode not supported
+    Fail  This mode is not supported for this board  skip
 
 PHILIP Setup UART
     [Documentation]             Setup uart parameters on PHiLIP


### PR DESCRIPTION
This allows the tests that do not support uart mode config to fail non-critically which shows a skip in the ci.  Similar to the GPIO tests.