### PR TITLE
periph_uart/Makefile: Add condition to build only if a uart device is specified

### DIFF
--- a/tests/periph_uart/Makefile
+++ b/tests/periph_uart/Makefile
@@ -8,6 +8,10 @@ FEATURES_OPTIONAL += periph_uart_modecfg
 USEMODULE += shell
 USEMODULE += xtimer
 
+ifeq ($(HIL_UART_DEV), )
+$(error ERROR: There is no specified uart device. This test requires 2 or more uarts)
+endif
+
 export HIL_UART_DEV
 
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
With this condition the uart test is only build if a uart device was specified in the environment of the board. If the HIL_UART_DEV is left blank the build fails with the given message.
This avoids that the test is build for boards that can't run it.