### PR TITLE
Add timer benchmarks

### DIFF
--- a/dist/robotframework/res/api_shell.keywords.txt
+++ b/dist/robotframework/res/api_shell.keywords.txt
@@ -68,6 +68,12 @@ API Firmware Should Match
     API Call Repeat on Timeout  Get Metadata
     Should Contain      ${RESULT['msg']}  ${firmware}
 
+API Firmware Data Should Match
+    [Documentation]     Verify that the DUT runs the required API test firmware
+    [Arguments]         ${firmware}=%{APPLICATION}
+    API Call Repeat on Timeout  Get Metadata
+    Should Contain      ${RESULT['data']}  ${firmware}
+
 API Sync Shell
     [Documentation]     Verify that the DUT runs the required API test firmware
     [Arguments]         ${firmware}=%{APPLICATION}

--- a/tests/xtimer_benchmarks/Makefile
+++ b/tests/xtimer_benchmarks/Makefile
@@ -1,0 +1,21 @@
+include ../Makefile.tests_common
+
+FEATURES_REQUIRED = periph_gpio
+
+USEMODULE += shell
+USEMODULE += random
+USEMODULE += xtimer
+
+USE_JSON_SHELL_PARSER ?= 1
+
+ifeq (,$(HIL_DUT_IC_PIN))
+$(error	HIL_DUT_IC_PIN not defined)
+endif
+ifeq (,$(HIL_DUT_IC_PORT))
+$(error	HIL_DUT_IC_PORT not defined)
+endif
+
+CFLAGS+= -DTIMER_TRACE_PIN=$(HIL_DUT_IC_PIN) -DTIMER_TRACE_PORT=$(HIL_DUT_IC_PORT)
+
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/xtimer_benchmarks/README.md
+++ b/tests/xtimer_benchmarks/README.md
@@ -1,0 +1,12 @@
+# xtimer_benchmarks test
+
+This application provides a wrapper for benchmarking xtimer via the RIOT shell.
+The application uses the GPIO pin defined by HIL_DUT_IC to trigger the IC pin on
+PHiLIP.
+
+Running this test on `samr21-xpro` with robot framework is done with this command:
+`BOARD=samr21-xpro PORT=/dev/ttyACM0 PHILIP_PORT=/dev/ttyACM1 HIL_DUT_IC_PORT=0 HIL_DUT_IC_PIN=19 make robot-test`
+
+where HIL_DUT_IC_PORT and HIL_DUT_IC_PIN are the RIOT specific pin identifiers
+of the DUT pin that is connected to PHiLIPs IC pin. Consult `dist/etc/conf/` for
+specific board configurations.

--- a/tests/xtimer_benchmarks/main.c
+++ b/tests/xtimer_benchmarks/main.c
@@ -1,0 +1,644 @@
+/*
+ * Copyright (C) 2020 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       RIOT timer benchmarks
+ *
+ * @author      M. Aiman Ismail <muhammadaimanbin.ismail@haw-hamburg.de>
+
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "periph/gpio.h"
+#include "test_utils/expect.h"
+#include "fmt.h"
+
+#include "shell.h"
+#include "test_helpers.h"
+#include "sc_args.h"
+#include "random.h"
+#include "timex.h"
+#include "mutex.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+#include "log.h"
+
+#ifndef PARSER_DEV_NUM
+#define PARSER_DEV_NUM 0
+#endif
+
+#define HIL_TEST_REPEAT     (50)
+#define HIL_MAX_TIMERS      (50)
+
+#define HIL_TEST_GPIO       GPIO_PIN(TIMER_TRACE_PORT, TIMER_TRACE_PIN)
+#define HIL_START_TIMER()   gpio_set(HIL_TEST_GPIO)
+#define HIL_STOP_TIMER()    gpio_clear(HIL_TEST_GPIO)
+#define HIL_TOGGLE_TIMER()  gpio_toggle(HIL_TEST_GPIO)
+
+#ifndef MODULE_ZTIMER
+#include "xtimer.h"
+
+#define TIMER_T                     xtimer_t
+#define TIMER_NOW()                 xtimer_now_usec()
+#define TIMER_SET(timer, duration)  xtimer_set(timer, duration)
+#define TIMER_REMOVE(timer)         xtimer_remove(timer)
+#define TIMER_SLEEP(duration)       xtimer_usleep(duration)
+#else
+#include "ztimer.h"
+
+#define TIMER_T                     ztimer_t
+#define ZTIMER_CLOCK                ZTIMER_USEC
+#define TIMER_NOW()                 ztimer_now(ZTIMER_CLOCK)
+#define TIMER_SET(timer, duration)  ztimer_set(ZTIMER_CLOCK, timer, duration)
+#define TIMER_REMOVE(timer)         ztimer_remove(ZTIMER_CLOCK, timer)
+#define TIMER_SLEEP(duration)       ztimer_sleep(ZTIMER_CLOCK, duration)
+#endif
+
+char printbuf[SHELL_DEFAULT_BUFSIZE] = { 0 };
+uint8_t in_buf[64];
+uint8_t out_buf[64];
+
+static TIMER_T test_timers[HIL_MAX_TIMERS];
+
+/* Default is whatever, just some small delay if the user forgets to initialize */
+static uint32_t spin_max = 64;
+
+/************************
+* HELPER FUNCTIONS
+************************/
+
+/**
+ * @brief   Busy wait (spin) for the given number of loop iterations
+ */
+static void spin(uint32_t limit)
+{
+    /* Platform independent busy wait loop, should never be optimized out
+     * because of the volatile asm statement */
+    while (limit--) {
+        __asm__ volatile ("");
+    }
+}
+
+void spin_random_delay(void)
+{
+    uint32_t limit = random_uint32_range(0, spin_max);
+
+    spin(limit);
+}
+
+/************************
+* OVERHEAD
+************************/
+
+#define OVERHEAD_SPREAD (1000UL)
+
+void cleanup_overhead(void)
+{
+    for (unsigned i = 0; i < HIL_MAX_TIMERS; ++i) {
+        TIMER_REMOVE(&test_timers[i]);
+    }
+}
+
+int overhead_gpio_cmd(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    gpio_clear(HIL_TEST_GPIO);
+
+    sprintf(printbuf, "gpio overhead");
+    print_cmd(PARSER_DEV_NUM, printbuf);
+    for (int i = 0; i < HIL_TEST_REPEAT; i++) {
+        HIL_START_TIMER();
+        HIL_STOP_TIMER();
+        HIL_START_TIMER();
+        HIL_STOP_TIMER();
+
+        TIMER_SLEEP(1000);
+    }
+    print_result(PARSER_DEV_NUM, TEST_RESULT_SUCCESS);
+    return 0;
+}
+
+int overhead_timer_now(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    sprintf(printbuf, "overhead timer now");
+    print_cmd(PARSER_DEV_NUM, printbuf);
+
+    gpio_clear(HIL_TEST_GPIO);
+
+    for (unsigned i = 0; i < HIL_TEST_REPEAT; ++i) {
+        spin_random_delay();
+        HIL_START_TIMER();
+        TIMER_NOW();
+        HIL_STOP_TIMER();
+    }
+
+    print_result(PARSER_DEV_NUM, TEST_RESULT_SUCCESS);
+    return 0;
+}
+
+static void _overhead_callback(void *arg)
+{
+    (void)arg;
+    expect(false);
+}
+
+uint32_t _delay(unsigned n)
+{
+    return 1 * US_PER_SEC + (OVERHEAD_SPREAD * n);
+}
+
+int timer_overhead_timer_cmd(int argc, char **argv)
+{
+    if (argc < 3) {
+        print_result(PARSER_DEV_NUM, TEST_RESULT_ERROR);
+        return -1;
+    }
+
+    gpio_clear(HIL_TEST_GPIO);
+
+    const char *method = argv[1];
+    const char *pos = argv[2];
+
+    sprintf(printbuf, "timer overhead: %s %s timer", method, pos);
+    print_cmd(PARSER_DEV_NUM, printbuf);
+
+    sprintf(printbuf, "%u", HIL_MAX_TIMERS);
+    print_data_dict_str(PARSER_DEV_NUM, "timer count", printbuf);
+
+    sprintf(printbuf, "%u", HIL_TEST_REPEAT);
+    print_data_dict_str(PARSER_DEV_NUM, "sample count", printbuf);
+
+    /* init the timers */
+    for (unsigned i = 0; i < HIL_MAX_TIMERS; ++i) {
+        test_timers[i].callback = _overhead_callback;
+    }
+
+    unsigned timer_idx = -1;
+    if (strcmp(pos, "first") == 0) {
+        timer_idx = 0;
+    }
+    else if (strcmp(pos, "middle") == 0) {
+        timer_idx = (HIL_MAX_TIMERS / 2) - 1;
+    }
+    else if (strcmp(pos, "last") == 0) {
+        timer_idx = HIL_MAX_TIMERS - 1;
+    }
+    else {
+        goto error;
+    }
+
+    if (strcmp(method, "set") == 0) {
+        for (unsigned n = 0; n < HIL_TEST_REPEAT; ++n) {
+            /* set all but the last timer */
+            for (unsigned i = 0; i < timer_idx; ++i) {
+                TIMER_SET(&test_timers[i], _delay(i));
+            }
+
+            spin_random_delay();
+
+            /* set the last timer */
+            HIL_START_TIMER();
+            TIMER_SET(&test_timers[timer_idx], _delay(timer_idx));
+            HIL_STOP_TIMER();
+
+            cleanup_overhead();
+        }
+    }
+    else if (strcmp(method, "remove") == 0) {
+        for (unsigned n = 0; n < HIL_TEST_REPEAT; ++n) {
+            /* set timers until timer_idx */
+            for (unsigned i = 0; i <= timer_idx; ++i) {
+                TIMER_SET(&test_timers[i], _delay(i));
+            }
+
+            spin_random_delay();
+
+            /* remove the timer at timer_idx */
+            HIL_START_TIMER();
+            TIMER_REMOVE(&test_timers[timer_idx]);
+            HIL_STOP_TIMER();
+
+            cleanup_overhead();
+        }
+    }
+    else {
+error:
+        cleanup_overhead();
+        print_result(PARSER_DEV_NUM, TEST_RESULT_ERROR);
+        return -1;
+    }
+
+    cleanup_overhead();
+
+    print_result(PARSER_DEV_NUM, TEST_RESULT_SUCCESS);
+    return 0;
+}
+
+int timer_overhead_nth_timer_cmd(int argc, char **argv)
+{
+    if (argc < 3) {
+        print_result(PARSER_DEV_NUM, TEST_RESULT_ERROR);
+        return -1;
+    }
+
+    gpio_clear(HIL_TEST_GPIO);
+
+    const char *method = argv[1];
+    unsigned timer_idx = atoi(argv[2]) - 1;
+
+    cleanup_overhead();
+
+    /* init the timers */
+    for (unsigned i = 0; i < HIL_MAX_TIMERS; ++i) {
+        test_timers[i].callback = _overhead_callback;
+    }
+
+    if (strcmp(method, "set") == 0) {
+        for (unsigned n = 0; n < HIL_TEST_REPEAT; ++n) {
+            /* set all but the last timer */
+            for (unsigned i = 0; i < timer_idx; ++i) {
+                TIMER_SET(&test_timers[i], _delay(i));
+            }
+
+            spin_random_delay();
+
+            /* set the last timer */
+            HIL_START_TIMER();
+            TIMER_SET(&test_timers[timer_idx], _delay(timer_idx));
+            HIL_STOP_TIMER();
+
+            cleanup_overhead();
+        }
+    }
+    else if (strcmp(method, "remove") == 0) {
+        for (unsigned n = 0; n < HIL_TEST_REPEAT; ++n) {
+            /* set all timer */
+            for (unsigned i = 0; i <= timer_idx; ++i) {
+                TIMER_SET(&test_timers[i], _delay(i));
+            }
+
+            spin_random_delay();
+
+            /* remove the last timer */
+            HIL_START_TIMER();
+            TIMER_REMOVE(&test_timers[timer_idx]);
+            HIL_STOP_TIMER();
+
+            cleanup_overhead();
+        }
+    }
+
+    print_result(PARSER_DEV_NUM, TEST_RESULT_SUCCESS);
+
+    return 0;
+}
+
+/************************
+* ACCURACY
+************************/
+
+void _sleep_accuracy_timer_set_cb(void *arg)
+{
+    HIL_STOP_TIMER();
+    bool *triggered = (bool *)arg;
+    *triggered = true;
+}
+
+int sleep_accuracy_timer_set_cmd(int argc, char **argv)
+{
+    if (argc < 2) {
+        print_result(PARSER_DEV_NUM, TEST_RESULT_ERROR);
+        return -1;
+    }
+
+    gpio_clear(HIL_TEST_GPIO);
+
+    int sleeptime = strtol(argv[1], NULL, 10);
+    if (sleeptime < 0) {
+        print_result(PARSER_DEV_NUM, TEST_RESULT_ERROR);
+        return -1;
+    }
+
+    sprintf(printbuf, "sleep_accuracy: timer_sleep(%s)", argv[1]);
+    print_cmd(PARSER_DEV_NUM, printbuf);
+
+    volatile bool triggered;
+    TIMER_T timer = {
+        .callback = _sleep_accuracy_timer_set_cb,
+        .arg = (void *)&triggered,
+    };
+
+    /* measure using PHiLIP */
+    for (unsigned i = 0; i < HIL_TEST_REPEAT; i++) {
+        spin_random_delay();
+        triggered = false;
+        HIL_START_TIMER();
+        TIMER_SET(&timer, sleeptime);
+        while (!triggered) {}
+    }
+
+    print_result(PARSER_DEV_NUM, TEST_RESULT_SUCCESS);
+    return 0;
+}
+
+int sleep_accuracy_timer_sleep_cmd(int argc, char **argv)
+{
+    if (argc < 2) {
+        print_result(PARSER_DEV_NUM, TEST_RESULT_ERROR);
+        return -1;
+    }
+
+    gpio_clear(HIL_TEST_GPIO);
+
+    sprintf(printbuf, "sleep_accuracy: timer_sleep(%s)", argv[1]);
+    print_cmd(PARSER_DEV_NUM, printbuf);
+
+    int sleeptime = strtol(argv[1], NULL, 10);
+    if (sleeptime < 0) {
+        print_result(PARSER_DEV_NUM, TEST_RESULT_ERROR);
+        return -1;
+    }
+
+    /* measure using PHiLIP */
+    for (unsigned i = 0; i < HIL_TEST_REPEAT; i++) {
+        spin_random_delay();
+        HIL_START_TIMER();
+        TIMER_SLEEP(sleeptime);
+        HIL_STOP_TIMER();
+    }
+
+    print_result(PARSER_DEV_NUM, TEST_RESULT_SUCCESS);
+    return 0;
+}
+
+/************************
+* JITTER
+************************/
+
+#define JITTER_TIMER_INTERVAL   (10 * MS_PER_SEC)
+#define JITTER_WAKEUPS       (2 * HIL_TEST_REPEAT)
+#define JITTER_START_RECORD  5
+
+typedef struct sleep_jitter_params {
+    TIMER_T *timer;
+    uint8_t idx;
+    uint8_t iter;
+    uint8_t recorded;
+} jitter_params_t;
+
+static mutex_t jitter_mutex = MUTEX_INIT_LOCKED;
+static jitter_params_t jitter_params[25];
+static uint32_t jitter_wakeups[JITTER_WAKEUPS];
+static uint32_t jitter_start;
+static bool start_record = false;
+static bool jitter_end = false;
+
+void cleanup_jitter(unsigned count, jitter_params_t *params)
+{
+    TIMER_SLEEP(1 * US_PER_SEC);
+    for (unsigned i = 0; i < count; ++i) {
+        TIMER_REMOVE(params[i].timer);
+    }
+
+    memset(jitter_params, 0, sizeof(jitter_params_t) * 25);
+    memset(jitter_wakeups, 0, sizeof(uint32_t) * 25);
+    jitter_start = 0;
+    start_record = false;
+    jitter_end = false;
+
+    HIL_STOP_TIMER();
+}
+
+static uint32_t _next_target(jitter_params_t *params)
+{
+    return (++params->iter * JITTER_TIMER_INTERVAL) + jitter_start;
+}
+
+static void jitter_main_cb(void *arg)
+{
+    jitter_params_t *params = (jitter_params_t *)arg;
+
+    if (!jitter_end) {
+        uint32_t now = TIMER_NOW();
+        if (start_record) {
+            HIL_TOGGLE_TIMER();
+            jitter_wakeups[params->recorded++] = now;
+        }
+        TIMER_SET(params->timer, _next_target(params) - now);
+
+        if (params->recorded  >= JITTER_WAKEUPS) {
+            jitter_end = true;
+            start_record = false;
+            mutex_unlock(&jitter_mutex);
+        }
+    }
+}
+
+static void jitter_cb(void *arg)
+{
+    if (!jitter_end) {
+        jitter_params_t *params = (jitter_params_t *)arg;
+        TIMER_SET(params->timer, _next_target(params) - TIMER_NOW());
+    }
+}
+
+int sleep_jitter_cmd(int argc, char **argv)
+{
+    if (argc < 2) {
+        print_data_str(PARSER_DEV_NUM, "Not enough arguments");
+        print_result(PARSER_DEV_NUM, TEST_RESULT_ERROR);
+        return -1;
+    }
+
+    print_cmd(PARSER_DEV_NUM, "sleep_jitter");
+
+    unsigned timer_count = atoi(argv[1]);
+    sprintf(printbuf, "%u", timer_count);
+    print_data_dict_str(PARSER_DEV_NUM, "timer-count", printbuf);
+
+    sprintf(printbuf, "%lu", JITTER_TIMER_INTERVAL);
+    print_data_dict_str(PARSER_DEV_NUM, "timer-interval", printbuf);
+
+    if (timer_count <= 0 || timer_count > ARRAY_SIZE(jitter_params)) {
+        print_data_str(PARSER_DEV_NUM, "timer count invalid");
+        print_result(PARSER_DEV_NUM, TEST_RESULT_ERROR);
+        return -1;
+    }
+
+    jitter_start = TIMER_NOW();
+    HIL_START_TIMER();
+
+    /* setup half of the background timers before the periodic timer */
+    for (unsigned i = 0; i < timer_count; i++) {
+        jitter_params[i].timer = &test_timers[i];
+        jitter_params[i].iter = 0;
+        jitter_params[i].idx = i;
+
+        TIMER_T *timer = jitter_params[i].timer;
+        timer->callback = (i < timer_count - 1) ? jitter_cb : jitter_main_cb;
+        timer->arg = &jitter_params[i];
+        TIMER_SET(timer, _next_target(&jitter_params[i]) - jitter_start);
+    }
+
+    start_record = true;
+
+    mutex_lock(&jitter_mutex);
+
+    /* Print DUT timer values */
+    printf(", { \"start-time\": %" PRIu32 "", jitter_start);
+    printf(", \"wakeups\": [");
+    for (unsigned i = 0; i < JITTER_WAKEUPS; ++i) {
+        printf("%" PRIu32 "%s", jitter_wakeups[i],
+               (i < JITTER_WAKEUPS - 1) ? "," : "]");
+    }
+    printf(" }");
+
+    cleanup_jitter(timer_count, jitter_params);
+
+    print_result(PARSER_DEV_NUM, TEST_RESULT_SUCCESS);
+    return 0;
+}
+
+/************************
+* DRIFT
+************************/
+
+int drift_cmd(int argc, char **argv)
+{
+    if (argc < 2) {
+        print_data_str(PARSER_DEV_NUM, "Not enough arguments");
+        print_result(PARSER_DEV_NUM, TEST_RESULT_ERROR);
+        return -1;
+    }
+
+    gpio_clear(HIL_TEST_GPIO);
+
+    uint32_t duration = atoi(argv[1]);  /* duration in microseconds */
+    sprintf(printbuf, "drift: %" PRIu32 " us", duration);
+    print_cmd(PARSER_DEV_NUM, printbuf);
+
+    uint32_t start = TIMER_NOW();
+    HIL_START_TIMER();
+    TIMER_SLEEP(duration);
+    HIL_STOP_TIMER();
+    uint32_t diff = TIMER_NOW() - start;
+
+    uint32_t us = diff % US_PER_SEC;
+    uint32_t sec = diff / US_PER_SEC;
+
+    sprintf(printbuf, "%" PRIu32 ".%06" PRIu32 "", sec, us);
+    print_data_str(PARSER_DEV_NUM, printbuf);
+
+    print_result(PARSER_DEV_NUM, TEST_RESULT_SUCCESS);
+    return 0;
+}
+
+/************************
+* ETC
+************************/
+
+int cmd_get_timer_version(int argc, char **argv)
+{
+    (void)argv;
+    (void)argc;
+
+#ifdef MODULE_ZTIMER
+    sprintf(printbuf, "ztimer");
+#else
+    sprintf(printbuf, "xtimer");
+#endif
+    print_data_str(PARSER_DEV_NUM, printbuf);
+    print_result(PARSER_DEV_NUM, TEST_RESULT_SUCCESS);
+    return 0;
+}
+
+int cmd_get_metadata(int argc, char **argv)
+{
+    (void)argv;
+    (void)argc;
+
+    print_data_str(PARSER_DEV_NUM, RIOT_BOARD);
+    print_data_str(PARSER_DEV_NUM, RIOT_VERSION);
+    print_data_str(PARSER_DEV_NUM, RIOT_APPLICATION);
+    print_result(PARSER_DEV_NUM, TEST_RESULT_SUCCESS);
+
+    return 0;
+}
+
+int cmd_gpio_clear(int argc, char **argv)
+{
+    (void)argv;
+    (void)argc;
+
+    gpio_clear(HIL_TEST_GPIO);
+
+    return 0;
+}
+
+int cmd_gpio_set(int argc, char **argv)
+{
+    (void)argv;
+    (void)argc;
+
+    gpio_set(HIL_TEST_GPIO);
+
+    return 0;
+}
+
+static const shell_command_t shell_commands[] = {
+    { "overhead_gpio", "Benchmark the gpio toggling overhead",
+      overhead_gpio_cmd },
+    { "overhead_timer_now", "timer now overhead",
+      overhead_timer_now },
+    { "overhead_timer", "timer set/remove overhead",
+      timer_overhead_timer_cmd },
+    { "overhead_timer_list", "timer nth list overhead",
+      timer_overhead_nth_timer_cmd },
+    { "sleep_accuracy_timer_sleep", "Sleep for specified time",
+      sleep_accuracy_timer_sleep_cmd },
+    { "sleep_accuracy_timer_set", "Sleep for specified time",
+      sleep_accuracy_timer_set_cmd },
+    { "sleep_jitter", "sleep jitter", sleep_jitter_cmd },
+    { "drift", "Drift Simple benchmark", drift_cmd },
+    { "get_metadata", "Get the metadata of the test firmware",
+      cmd_get_metadata },
+    { "get_timer_version", "Get timer version", cmd_get_timer_version },
+    { "gclear", "clear", cmd_gpio_clear },
+    { "gset", "set", cmd_gpio_set },
+    { NULL, NULL, NULL }
+};
+
+int main(void)
+{
+    (void)puts("Welcome to RIOT!");
+
+    gpio_init(HIL_TEST_GPIO, GPIO_OUT);
+    /* clear initial state */
+    gpio_clear(HIL_TEST_GPIO);
+
+    random_init(0);
+
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    return 0;
+}

--- a/tests/xtimer_benchmarks/tests/00__timer_version.robot
+++ b/tests/xtimer_benchmarks/tests/00__timer_version.robot
@@ -1,0 +1,20 @@
+*** Settings ***
+Library    DutDeviceIf    port=%{PORT}    baudrate=%{BAUD}    timeout=${%{HIL_CMD_TIMEOUT}}    connect_wait=${%{HIL_CONNECT_WAIT}}    parser=json
+
+Resource    api_shell.keywords.txt
+Resource    philip.keywords.txt
+Resource    util.keywords.txt
+
+Suite Setup    Run Keywords
+...            RIOT Reset
+...            PHILIP Reset
+...            API Firmware Data Should Match
+Test Setup     Run Keywords
+...            PHILIP Reset
+...            API Sync Shell
+
+*** Test Cases ***
+Save Timer Version
+    [Documentation]             Record the timer version
+    API Call Should Succeed     Get Timer Version
+    Record Property             timer-version     ${RESULT['data'][0]}

--- a/tests/xtimer_benchmarks/tests/01__timer_overhead.robot
+++ b/tests/xtimer_benchmarks/tests/01__timer_overhead.robot
@@ -1,0 +1,98 @@
+*** Settings ***
+Library    DutDeviceIf    port=%{PORT}    baudrate=%{BAUD}    timeout=${%{HIL_CMD_TIMEOUT}}    connect_wait=${%{HIL_CONNECT_WAIT}}    parser=json
+
+Resource    api_shell.keywords.txt
+Resource    philip.keywords.txt
+Resource    util.keywords.txt
+
+Suite Setup    Run Keywords
+...            RIOT Reset
+...            PHILIP Reset
+...            API Firmware Data Should Match
+Test Setup     Run Keywords
+...            PHILIP Reset
+...            API Sync Shell
+
+*** Keywords ***
+Test Teardown
+    Run Keyword If  '${KEYWORD_STATUS}' != 'PASS'     RIOT Reset
+    PHILIP Reset
+
+Measure Timer Overhead
+    [Arguments]    ${no}    ${method}    ${position}
+    [Teardown]  Test Teardown
+
+    API Call Should Succeed    Overhead Timer                 ${method}                      ${position}
+    ${RESULT}=                 Run Keyword                    DutDeviceIf.Compress Result    data=${RESULT['data']}
+    Record Property            timer-count                    ${RESULT['timer count']}
+    Record Property            sample-count                   ${RESULT['sample count']}
+    API Call Should Succeed    PHILIP.Read Trace
+    ${RESULT}=                 DutDeviceIf.Filter Trace       trace=${RESULT['data']}        select=FALLING
+    ${OVERHEAD}=               DutDeviceIf.Compress Result    ${RESULT}
+
+    Record Property    overhead-${no}-${method}-${position}-timer    ${OVERHEAD['diff']}
+
+Measure Timer List Overhead
+    [Arguments]     ${method}  ${position}
+    [Teardown]  Test Teardown
+
+    API Call Should Succeed    Overhead Timer List            ${method}  ${position}
+    API Call Should Succeed    PHILIP.Read Trace
+    ${RESULT}=                 DutDeviceIf.Filter Trace       trace=${RESULT['data']}        select=FALLING
+    ${OVERHEAD}=               DutDeviceIf.Compress Result    ${RESULT}
+
+    Record Property     00-overhead-${position}-${method}    ${OVERHEAD['diff']}
+
+
+Measure Timer Now Overhead
+    [Teardown]  Test Teardown
+
+    API Call Should Succeed    Overhead Timer Now
+    API Call Should Succeed    PHILIP.Read Trace
+    ${RESULT}=                 DutDeviceIf.Filter Trace         trace=${RESULT['data']}    select=FALLING
+    ${OVERHEAD}=               DutDeviceIf.Compress Result      ${RESULT}
+    Record Property            overhead-01-timer-now            ${OVERHEAD['diff']}
+
+Measure GPIO Overhead
+    [Teardown]  Test Teardown
+
+    Run Keyword  PHILIP.Write and Execute  tmr.mode.trig_edge  1
+
+    API Call Should Succeed    Overhead GPIO
+    API Call Should Succeed    PHILIP.Read Trace
+
+    # ${RESULT}=                 DutDeviceIf.Filter Trace                   trace=${RESULT['data']}     select=FALLING
+    ${GPIO_OVERHEAD}=          DutDeviceIf.Compress Result                ${RESULT['data']}
+    Record Property            overhead-00-gpio                              ${GPIO_OVERHEAD['diff']}
+
+Set ${count} Timers
+    [Documentation]            Run the list operations benchmark
+    [Teardown]  Test Teardown
+
+    API Call Should Succeed    DutDeviceIf.List Operation       ${count}
+    API Call Should Succeed    PHILIP.Read Trace
+    ${PHILIP_RES}=             DutDeviceIf.Filter Trace         ${RESULT['data']}    select=FALLING
+    ${RESULT}=                 DutDeviceIf.Compress Result      ${PHILIP_RES}
+
+    Record Property            ${count}-timer-trace             ${RESULT['diff']}
+
+*** Test Cases ***
+Measure GPIO
+    [Teardown]  Run Keywords  PHILIP Reset
+    Repeat Keyword  20  Measure GPIO Overhead
+
+Measure Overhead TIMER_NOW
+    [Teardown]  Run Keywords  PHILIP Reset
+    Repeat Keyword  20  Measure Timer Now Overhead
+
+Measure Overhead Set List
+    [Teardown]  Run Keyword     PHILIP Reset
+    FOR  ${n}  IN RANGE  25
+        Repeat Keyword  1 times  Measure Timer List Overhead     set     ${n + 1}
+    END
+
+Measure Overhead Remove List
+    [Teardown]  Run Keyword     PHILIP Reset
+    FOR  ${n}  IN RANGE  25
+        Repeat Keyword  1 times  Measure Timer List Overhead     remove     ${n + 1}
+    END

--- a/tests/xtimer_benchmarks/tests/02__sleep_accuracy.robot
+++ b/tests/xtimer_benchmarks/tests/02__sleep_accuracy.robot
@@ -1,0 +1,41 @@
+*** Settings ***
+Library    DutDeviceIf    port=%{PORT}    baudrate=%{BAUD}    timeout=${%{HIL_CMD_TIMEOUT}}    connect_wait=${%{HIL_CONNECT_WAIT}}    parser=json
+
+Resource    api_shell.keywords.txt
+Resource    philip.keywords.txt
+
+Suite Setup    Run Keywords
+...            RIOT Reset
+...            PHILIP Reset
+...            API Firmware Data Should Match
+Test Setup     Run Keywords
+...            PHILIP Reset
+...            API Sync Shell
+
+*** Keywords ***
+Test Teardown
+    Run Keyword If  '${KEYWORD_STATUS}' != 'PASS'     RIOT Reset
+    PHILIP Reset
+
+Measure Sleep Accuracy with ${type} for ${duration}
+    [Documentation]            Sleep for specified duration in microseconds (us)
+    [Teardown]  Test Teardown
+    API Call Should Succeed    Sleep Accuracy                                       ${type}                    ${duration}
+    API Call Should Succeed    PHILIP.Read Trace
+    ${RESULT}=                 DutDeviceIf.Filter Trace                             trace=${RESULT['data']}    select=FALLING
+    ${ACCURACY}=               DutDeviceIf.Compress Result                          ${RESULT}
+    Record Property            accuracy-${type}-${duration}-philip                  ${ACCURACY['diff']}
+
+*** Test Cases ***
+Measure TIMER_SET Accuracy
+    [Teardown]  Run Keywords  PHILIP Reset
+    FOR     ${duration}     IN RANGE    1    101
+        Measure Sleep Accuracy with TIMER_SET for ${duration}
+    END
+
+Measure TIMER_SLEEP Accuracy
+    [Teardown]  Run Keywords  PHILIP Reset
+    FOR     ${duration}     IN RANGE    1    101
+        Measure Sleep Accuracy with TIMER_SLEEP for ${duration}
+    END
+

--- a/tests/xtimer_benchmarks/tests/03__sleep_jitter.robot
+++ b/tests/xtimer_benchmarks/tests/03__sleep_jitter.robot
@@ -1,0 +1,39 @@
+*** Settings ***
+Library    DutDeviceIf    port=%{PORT}    baudrate=%{BAUD}    timeout=${%{HIL_CMD_TIMEOUT}}    connect_wait=${%{HIL_CONNECT_WAIT}}    parser=json
+
+Resource    api_shell.keywords.txt
+Resource    philip.keywords.txt
+
+Suite Setup    Run Keywords
+...            RIOT Reset
+...            PHILIP Reset
+...            API Firmware Data Should Match
+Test Setup     Run Keywords
+...            PHILIP Reset
+...            API Sync Shell
+
+*** Keywords ***
+Test Teardown
+    Run Keyword If  '${KEYWORD_STATUS}' != 'PASS'     RIOT Reset
+    PHILIP Reset
+
+Measure Sleep Jitter With ${timer_count} Timers
+    [Documentation]            Run the sleep jitter benchmark
+    [Teardown]                 Test Teardown
+
+    API Call Should Succeed    Sleep Jitter                     ${timer_count}
+    ${RESULT}=                 DutDeviceIf.Compress Result      ${RESULT['data']}
+    Record Property            timer-interval                   ${RESULT['timer-interval']}
+    Record Property            dut-${timer_count}-start-time    ${RESULT['start-time']}
+    Record Property            dut-${timer_count}-wakeup-time   ${RESULT['wakeups']}
+
+    API Call Should Succeed    PHILIP.Read Trace
+    ${RESULT}=                 DutDeviceIf.Compress Result      ${RESULT['data']}
+    Record Property            hil-${timer_count}-start-time    ${RESULT['time'][0]}
+    Record Property            hil-${timer_count}-wakeup-time   ${RESULT['time'][1:-1]} # exclude start event
+
+*** Test Cases ***
+Measure Sleep Jitter With Increasing Timers
+    FOR  ${n}  IN RANGE  10
+        Repeat Keyword  3 Times     Measure Sleep Jitter With ${n + 1} Timers
+    END

--- a/tests/xtimer_benchmarks/tests/04__drift.robot.skip
+++ b/tests/xtimer_benchmarks/tests/04__drift.robot.skip
@@ -1,0 +1,40 @@
+*** Settings ***
+Library    DutDeviceIf    port=%{PORT}    baudrate=%{BAUD}    timeout=${%{HIL_CMD_TIMEOUT}}    connect_wait=${%{HIL_CONNECT_WAIT}}    parser=json
+
+Resource    api_shell.keywords.txt
+Resource    philip.keywords.txt
+
+Suite Setup    Run Keywords
+...            RIOT Reset
+...            PHILIP Reset
+...            API Firmware Data Should Match
+Test Setup     Run Keywords
+...            PHILIP Reset
+...            API Sync Shell
+
+Force Tags     long
+
+*** Keywords ***
+Measure Drift
+    [Documentation]            Run the drift simple benchmark
+    [Arguments]                ${duration}
+    [Teardown]                 Run Keywords                          PHILIP Reset         API Sync Shell
+    FOR                        ${i}                                  IN RANGE             5
+    API Call Should Succeed    Drift                                 ${duration}
+    Record Property            dut-result-${duration}-repeat-${i}    ${RESULT['data']}
+
+    API Call Should Succeed    PHILIP.Read Trace
+    ${PHILIP_RES}=             DutDeviceIf.Filter Trace                 ${RESULT['data']}    select=FALLING
+    ${RESULT}=                 DutDeviceIf.Compress Result              ${PHILIP_RES}
+    Record Property            philip-result-${duration}-repeat-${i}    ${RESULT['diff']}
+    PHILIP Reset
+    END
+
+*** Test Cases ***
+Measure Drift Template
+    [Teardown]  Run Keywords  PHILIP Reset
+    [Template]  Measure Drift
+    1000000
+    15000000
+    30000000
+    45000000

--- a/tests/xtimer_benchmarks/tests/DutDeviceIf.py
+++ b/tests/xtimer_benchmarks/tests/DutDeviceIf.py
@@ -1,0 +1,136 @@
+# Copyright (C) 2019 Kevin Weiss <kevin.weiss@haw-hamburg.de>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.z
+"""@package PyToAPI
+This module handles parsing of information from RIOT periph_gpio test.
+"""
+from riot_pal import DutShell
+from robot.api import logger
+from robot.version import get_version
+from ast import literal_eval
+
+
+class DutDeviceIf(DutShell):
+    """Interface to the node."""
+
+    ROBOT_LIBRARY_SCOPE = "TEST"
+    ROBOT_LIBRARY_VERSION = get_version()
+
+    def get_metadata(self):
+        """Get the metadata of the firmware."""
+        return self.send_cmd("get_metadata")
+
+    def get_timer_version(self):
+        """Get the version of timer used"""
+        return self.send_cmd("get_timer_version")
+
+    def overhead_gpio(self):
+        """Run the GPIO toggling overhead benchmark"""
+        return self.send_cmd("overhead_gpio")
+
+    def overhead_timer_now(self):
+        """Run the overhead timer_now function benchmark"""
+        return self.send_cmd("overhead_timer_now")
+
+    def overhead_timer(self, method, position):
+        """Run the overhead timer benchmark"""
+        return self.send_cmd("overhead_timer {} {}".format(method, position))
+
+    def overhead_timer_list(self, method, position):
+        """Run the overhead timer list benchmark"""
+        return self.send_cmd("overhead_timer_list {} {}".format(method, position))
+
+    def sleep_accuracy_timer_sleep(self, duration):
+        """Run the sleep accuracy benchmark"""
+        return self.send_cmd("sleep_accuracy_timer_sleep {}".format(duration))
+
+    def sleep_accuracy_timer_set(self, duration):
+        """Run the sleep accuracy benchmark"""
+        return self.send_cmd("sleep_accuracy_timer_set {}".format(duration))
+
+    def sleep_accuracy(self, call, duration):
+        if call == "TIMER_SLEEP":
+            return self.sleep_accuracy_timer_sleep(duration)
+        elif call == "TIMER_SET":
+            return self.sleep_accuracy_timer_set(duration)
+        else:
+            return {"result": "Error"}
+
+    def sleep_jitter(self, timer_count):
+        """Run the sleep jitter benchmark"""
+        return self.cmd_extended_timeout("sleep_jitter {}".format(timer_count), 10)
+
+    def drift(self, duration):
+        """Run the drift simple benchmark"""
+        return self.cmd_extended_timeout("drift {}".format(duration), 75)
+
+    def list_operation(self, count):
+        """Set N timers"""
+        return self.send_cmd("list_ops {}".format(count))
+
+    ## HELPER FUNCTIONS
+
+    def cmd_extended_timeout(self, command, timeout):
+        old_timeout = self.dev._driver._dev.timeout
+        self.dev._driver._dev.timeout = timeout
+        res = self.send_cmd(command)
+        self.dev._driver._dev.timeout = old_timeout
+        return res
+
+    def get_dict_data(self, data, key):
+        """Get data from dict"""
+        assert isinstance(data, list)
+        values = []
+        for e in data:
+            if not isinstance(e, dict):
+                continue
+            if key in e:
+                try:
+                    values.append(float(e[key]))
+                except ValueError:
+                    values.append(e[key])
+        return values if len(values) > 1 else values[0]
+
+    @staticmethod
+    def filter_trace(trace, select: str):
+        """Filter the given data from a trace
+
+        Use only on uncompressed trace data.
+
+        Args:
+            select: A string key to filter.
+                    Events containing this string will be included in the filtered result.
+        Returns:
+            A list of dictionaries containing the filtered data
+        """
+
+        if not isinstance(select, str):
+            raise RuntimeError("Wrong type for select")
+
+        return [event for event in trace if select in event.values()]
+
+    @staticmethod
+    def compress_result(data, key=None):
+        """Only use with data containing dicts as follows:
+
+        Simplifies data from
+        data = "[{"focus":"1000000"},{"interval":"1000000"},{"interval":"2000000"},{"interval":"2000000"}]
+
+        to
+
+        data = "{"focus": [1000000], "interval": [1000000, 2000000, 2000000"
+        """
+        result = dict()
+        keyset = set([k for e in data for k in e.keys()])
+        for k in keyset:
+            values = []
+            for e in data:
+                if k in e:
+                    try:
+                        values.append(literal_eval(e[k]))
+                    except ValueError:
+                        values.append(e[k])
+            result[k] = values if len(values) > 1 else values[0]
+        return result

--- a/tests/ztimer_benchmarks/Makefile
+++ b/tests/ztimer_benchmarks/Makefile
@@ -1,0 +1,20 @@
+include ../Makefile.tests_common
+
+FEATURES_REQUIRED = periph_gpio
+
+USEMODULE += shell
+USEMODULE += random
+USEMODULE += ztimer_usec
+
+USE_JSON_SHELL_PARSER ?= 1
+
+ifeq (,$(HIL_DUT_IC_PIN))
+$(error	HIL_DUT_IC_PIN not defined)
+endif
+ifeq (,$(HIL_DUT_IC_PORT))
+$(error	HIL_DUT_IC_PORT not defined)
+endif
+
+CFLAGS+= -DTIMER_TRACE_PIN=$(HIL_DUT_IC_PIN) -DTIMER_TRACE_PORT=$(HIL_DUT_IC_PORT)
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/ztimer_benchmarks/README.md
+++ b/tests/ztimer_benchmarks/README.md
@@ -1,0 +1,3 @@
+# ztimer_benchmarks test
+
+See `tests/xtimer_benchmarks/README.md`.

--- a/tests/ztimer_benchmarks/main.c
+++ b/tests/ztimer_benchmarks/main.c
@@ -1,0 +1,1 @@
+../xtimer_benchmarks/main.c

--- a/tests/ztimer_benchmarks/tests
+++ b/tests/ztimer_benchmarks/tests
@@ -1,0 +1,1 @@
+../xtimer_benchmarks/tests/


### PR DESCRIPTION
This PR adds two new testsuites one for xtimer and ztimer with the timer benchmarks. This also adds plotting script for the results of the benchmark and outputs it into the `includes` folder in the results directory.

There are some helper functions in `DutDeviceIf.py` (`filter_trace`, `compress_result`) which translate the output format from `print_result` to a more friendlier format to work with.