### PR TITLE
Jenkinsfile: archive generated timer benchmarks plots

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -181,5 +181,6 @@ def stepArchiveTestResults(test)
     sh "make -C ${test} robot-html || true"
     archiveArtifacts artifacts: "build/robot/${env.BOARD}/${test_name}/*.xml"
     archiveArtifacts artifacts: "build/robot/${env.BOARD}/${test_name}/*.html"
+    archiveArtifacts artifacts: "build/robot/${env.BOARD}/${test_name}/includes/*.html"
     junit "build/robot/${env.BOARD}/${test_name}/xunit.xml"
 }


### PR DESCRIPTION
This PR modifies the Jenkinsfile to also archive benchmark plots that will be generated by `dist/tools/plot/plot_timer_benchmark.py` from #82. It is split from that PR for easier testing.