### PR TITLE
dist/, tests/: rename "skip" tag to "non-critical"

### DIFF
--- a/dist/robotframework/Makefile.include
+++ b/dist/robotframework/Makefile.include
@@ -5,8 +5,9 @@ RFOUTPATH ?= $(BUILD_DIR)/robot/$(BOARD)/$(APPLICATION)
 ROBOT_TESTDIR ?= tests/
 
 $(RFOUTPATH)/output.xml: $(ROBOT_TESTDIR)
-	-python3 -m robot.run --noncritical skip \
+	-python3 -m robot.run \
 				--name "$(APPLICATION)" \
+				--noncritical non-critical \
 				--noncritical warn-if-failed \
 				--settag "APP_$(APPLICATION)" \
 				--settag "BOARD_$(BOARD)" \
@@ -26,7 +27,7 @@ $(RFOUTPATH)/output.xml: $(ROBOT_TESTDIR)
 robot-test: $(RFOUTPATH)/output.xml
 
 robot-html:  $(RFOUTPATH)/output.xml
-	python3 -m robot.rebot --noncritical skip -d $(RFOUTPATH) $<
+	python3 -m robot.rebot --noncritical non-critical -d $(RFOUTPATH) $<
 
 robot-clean:
 	@rm -f $(RFOUTPATH)/*.xml

--- a/dist/tools/output_to_xunit/README.md
+++ b/dist/tools/output_to_xunit/README.md
@@ -6,7 +6,7 @@ Parses `output.xml` from a RobotFramework result to a xUnit style format. The pa
 
 ```
 # Run tests and generate output.xml
-robot --outputdir build --pythonpath "test:../../robotframework/res/" --noncritical skip --noncritical warn-if-failed test/example_testsuite/
+robot --outputdir build --pythonpath "test:../../robotframework/res/" --noncritical non-critical --noncritical warn-if-failed test/example_testsuite/
 
 # Parse output and generate xunit.xml in the current directory (default)
 python3 output_to_xunit.py build/output.xml
@@ -15,7 +15,7 @@ python3 output_to_xunit.py build/output.xml
 python3 output_to_xunit.py --output build/test_xunit.xml build/output.xml
 ```
 
-NOTE: `Test Failed Testcase` and `Test Fail Skipped Testcase` is supposed to fail.
+NOTE: `Test Failed Testcase` and `Test Fail Non-Critical Testcase` is supposed to fail.
 
 ## Schema Validation
 

--- a/dist/tools/output_to_xunit/test/example_testsuite/example_test.robot
+++ b/dist/tools/output_to_xunit/test/example_testsuite/example_test.robot
@@ -18,10 +18,10 @@ Passed Testcase
     Pass Execution  TEST PASSED
 Failed Testcase
     Fail            TEST FAILED
-Pass Skipped Testcase
-    Set Tags        skip
-Fail Skipped Testcase
-    Set Tags  skip
+Pass Non-Critical Testcase
+    Set Tags        non-critical
+Fail Non-Critical Testcase
+    Set Tags        non-critical
     Fail
 Record Empty value
     Call Library        TestData.Get Empty

--- a/tests/periph_gpio/tests/periph_gpio.keywords.txt
+++ b/tests/periph_gpio/tests/periph_gpio.keywords.txt
@@ -54,4 +54,4 @@ Verify Periph Pin Is Connected Continue
 
 
 Verify Periph Pin Is Connected Fail
-    Fail  This Periph is not supported here  skip
+    Fail  This Periph is not supported here  non-critical

--- a/tests/periph_uart/tests/periph_uart.keywords.txt
+++ b/tests/periph_uart/tests/periph_uart.keywords.txt
@@ -39,7 +39,7 @@ UART Mode Should Exist
     Run Keyword If              '${status}'=='FAIL'  UART Mode not supported
 
 UART Mode not supported
-    Fail  This mode is not supported for this board  skip
+    Fail  This mode is not supported for this board  non-critical
 
 PHILIP Setup UART
     [Documentation]             Setup uart parameters on PHiLIP


### PR DESCRIPTION
The current "skip" tag are used to mark a failing test that are not fatal to the test suite. However, this can confuse user that the test are skipped/not run at all. This PR renames the "skip" tag to "non-critical" in the RF files and also the `output_to_xunit.py` script.

### Testing Procedure

For `output_to_xunit.py`, there is a test RF suite that can be use. Follow the testing instruction in the README there. The final xunit.xml should have one  test case marked as skipped.

For the changes to RF files, let the HIL CI run through the test. The result should be the same as the nightlies.
