### PR TITLE
Jenkinsfile: remove whitespace before tokenizing board and test list

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -414,7 +414,7 @@ def stepGetBoards() {
         nodeBoards = getBoardsFromNodesEnv()
     }
     else {
-        nodeBoards = params.HIL_BOARDS.tokenize(',')
+        nodeBoards = params.HIL_BOARDS.replaceAll("\\s", "").tokenize(',')
         /* TODO: Validate if the boards are connected */
     }
     sh script: "echo collected boards: ${nodeBoards.join(",")}",
@@ -445,7 +445,7 @@ def stepGetTests() {
         nodeTests = getTestsFromDir()
     }
     else {
-        nodeTests = params.HIL_TESTS.tokenize(',')
+        nodeTests = params.HIL_TESTS.replaceAll("\\s", "").tokenize(',')
     }
 
     sh script: "echo collected tests: ${nodeTests.join(",")}",


### PR DESCRIPTION
Current HIL_TESTS and HIL_BOARDS must not include any whitespace between the item list e.g. `samr21-xpro,saml10-xpro`. If the user adds whitespace between the comma and the next item in the list, the pipeline will interpret the whitespace as part of the item name.

This caused archiving artifacts steps failed because it cannot find tests with the whitespace name in it. Here is a excerpt of failure from [a pipeline run](https://ci.riot-os.org/hil/blue/organizations/jenkins/RIOT-HIL/detail/PR-90/16/pipeline/490):
```
Archiving artifacts

‘build/robot/arduino-due/ tests_ztimer_benchmarks/*.xml’ doesn’t match anything: ‘build’ exists but not ‘build/robot/arduino-due/ tests_ztimer_benchmarks/*.xml’

No artifacts found that match the file pattern "build/robot/arduino-due/ tests_ztimer_benchmarks/*.xml,build/robot/arduino-due/ tests_ztimer_benchmarks/*.html,build/robot/arduino-due/ tests_ztimer_benchmarks/*.html,build/robot/arduino-due/ tests_ztimer_benchmarks/includes/*.html". Configuration error?
```

This PR strips any whitespace in the full list before it is tokenized.

### Testing

Try specifying either HIL_TESTS or HIL_BOARDS with and without whitespace between the items.
- HIL_TESTS with whitespace: `tests/periph_gpio, tests/periph_