### PR TITLE
Remove relation to deprecated XSL-Stylesheet in results_to_xml.sh

### DIFF
--- a/dist/tools/ci/results_to_xml.sh
+++ b/dist/tools/ci/results_to_xml.sh
@@ -9,7 +9,6 @@ METAXML=$BASEDIR/metadata.xml
 
 # write header to xml
 echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" > $BASEXML
-echo "<?xml-stylesheet type=\"text/xsl\" href=\"https://ci.riot-os.org/static/robot.xsl\"?>" >> $BASEXML
 echo "<result name=\"RIOT HIL\">" >> $BASEXML
 tail -n+2 $METAXML >> $BASEXML
 echo "<boards>" >> $BASEXML


### PR DESCRIPTION
The old robot.xsl stylesheet is still included in the current xml result files but is no longer needed and can be safely removed.