### PR TITLE
output_to_xml: Fix return code of robot-test

### DIFF
--- a/dist/tools/output_to_xunit/output_to_xunit.py
+++ b/dist/tools/output_to_xunit/output_to_xunit.py
@@ -1,4 +1,5 @@
 #! /usr/bin/env python3
+import sys
 import argparse
 import xml.etree.ElementTree as ET
 from datetime import datetime as DT
@@ -118,3 +119,6 @@ for tc in testsuite["testcases"]:
 
 newtree = ET.ElementTree(newroot)
 newtree.write(args.output, encoding="UTF-8", xml_declaration=True)
+
+# To catch failures in make we add failures to the exit code
+sys.exit(int(total_all.get("fail")))


### PR DESCRIPTION
It also allows for the exit code of `make robot-test` to return the amount of failed tests thus allowing the CI to properly indicate failures.

This is useful for the comment on PR...