### PR TITLE
tests/periph_spi: Improve timer tests

### DIFF
--- a/tests/periph_spi/tests/04__periph_spi_timer.robot
+++ b/tests/periph_spi/tests/04__periph_spi_timer.robot
@@ -1,5 +1,5 @@
 *** Settings ***
-Documentation       Verify that the meassured times are within a certain window
+Documentation       Verify that the measured times are within a certain window
 
 Suite Setup         Run Keywords    PHILIP Reset
 ...                                 RIOT Reset
@@ -13,6 +13,7 @@ Test Teardown       Run Keywords    SPI Release Should Succeed
 
 Resource            periph_spi.keywords.txt
 Resource            api_shell.keywords.txt
+Resource            util.keywords.txt
 
 Variables           test_vars.py
 
@@ -20,59 +21,84 @@ Force Tags          periph  spi
 
 
 *** Keywords ***
-SPI Clock Speed Check
+SPI Clock Speed Check Setup
     [Documentation]     Main routine to verify the clock speed
     [Arguments]         ${clk_speed_string}  ${clk_speed_value}  ${size}
+    Set Test Variable                   ${size}
     PHiLIP.write and execute            spi.mode.if_type    3
-    SPI Acquire Should Succeed          0  ${clk_speed_string}
-    SPI Transfer Bytes Should Succeed   cont=0   in_len=${size}
-    API Call Should Succeed             PHiLIP.Read Reg         sys.sys_clk
-    ${sys_clk} =  Set Variable          ${RESULT['data']}
-    API Call Should Succeed             PHiLIP.Read Reg         spi.byte_ticks
-    ${spi_speed_limits} =  Set Variable  
-    ...  ${spi_speed_limits(${clk_speed_value}, ${sys_clk}, ${size})}
-    Should Be True  
-    ...  ${spi_speed_limits}[0] < ${${RESULT['data']} * ${size}} and ${spi_speed_limits}[1] > ${${RESULT['data']} * ${size}}
-    ...  Time should be between ${convert_ticks_to_us(${spi_speed_limits[0]},${sys_clk})}us and ${convert_ticks_to_us(${spi_speed_limits[1]},${sys_clk})}us but was ${convert_ticks_to_us(${RESULT['data']} * ${size}, ${sys_clk})}us
+    SPI Acquire Should Succeed          0                   ${clk_speed_string}
+    SPI Transfer Bytes Should Succeed   cont=0              in_len=${size}
+    API Call Should Succeed             PHiLIP.Read Reg     sys.sys_clk
+    Set Test Variable                   ${sys_clk}          ${RESULT['data']}
+    API Call Should Succeed             PHiLIP.Read Reg     spi.byte_ticks
+    Set Test Variable                   ${byte_ticks}       ${RESULT['data']}
+    IF  ${byte_ticks} == 0
+        Fail  Error with the measurement. byte_ticks == 0.
+    END
+
+    Set Test Variable                   ${comparison}
+    ...                                     ${spi_speed_comparison(${clk_speed_value}, ${byte_ticks}, ${sys_clk})}
+
+
+    Record Property     expected_freq   ${clk_speed_value}
+    Record Property     measured_freq   ${comparison['measured_freq']}
+    Record Property     diff_pct        ${comparison['difference_percentage']}
+    Record Property     byte_count      ${size}
+
+    IF   not ${comparison['pass']}
+        Run Keyword
+        ...  Fail Test  ${comparison['difference_percentage']}  ${comparison['measured_freq']}
+    ELSE IF  ${comparison['warn']}
+        Run Keyword And Warn On Failure
+        ...  Fail Test  ${comparison['difference_percentage']}  ${comparison['measured_freq']}
+    ELSE
+        Pass Execution  Measured frequency is ${comparison['measured_freq']}Hz and within range.
+    END
+
+
+Fail Test
+    [Documentation]     Fails the test and gives a unified message
+    [Arguments]         ${difference_percentage}  ${measured_freq}
+    Fail                Clock speed is ${difference_percentage}% off. Measured frequency: ${measured_freq}Hz
 
 
 *** Test Cases ***
-Clock Speed 100k Should Succeed
-    [Documentation]  Checks the clock speed for 100kHz
-    SPI Clock Speed Check    100k     100000    1
+Clock Speed 100k Should Succeed 2 Byte
+    [Documentation]  Checks the clock speed for 100kHz with 2 bytes
+    SPI Clock Speed Check Setup    100k     100000    2
 
-Clock Speed 100k Should Succeed 8 Byte
-    [Documentation]  Checks the clock speed for 100kHz
-    SPI Clock Speed Check    100k     100000    8
+Clock Speed 100k Should Succeed 3 Byte
+    [Documentation]  Checks the clock speed for 100kHz with 3 bytes
+    SPI Clock Speed Check Setup    100k     100000    3
 
-Clock Speed 400k Should Succeed
-    [Documentation]  Checks the clock speed for 400kHz
-    SPI Clock Speed Check    400k     400000    1
+Clock Speed 400k Should Succeed 2 Byte
+    [Documentation]  Checks the clock speed for 400kHz with 2 bytes
+    SPI Clock Speed Check Setup    400k     400000    2
 
-Clock Speed 400k Should Succeed 8 Byte
-    [Documentation]  Checks the clock speed for 400kHz
-    SPI Clock Speed Check    400k     400000    8
+Clock Speed 400k Should Succeed 3 Byte
+    [Documentation]  Checks the clock speed for 400kHz with 3 bytes
+    SPI Clock Speed Check Setup    400k     400000    3
 
-Clock Speed 1M Should Succeed
-    [Documentation]  Checks the clock speed for 1MHz
-    SPI Clock Speed Check      1M    1000000    1
+Clock Speed 1M Should Succeed 2 Byte
+    [Documentation]  Checks the clock speed for 1MHz with 2 bytes
+    SPI Clock Speed Check Setup      1M    1000000    2
 
-Clock Speed 1M Should Succeed 8 Byte
-    [Documentation]  Checks the clock speed for 1MHz
-    SPI Clock Speed Check      1M    1000000    8
+Clock Speed 1M Should Succeed 3 Byte
+    [Documentation]  Checks the clock speed for 1MHz with 3 bytes
+    SPI Clock Speed Check Setup      1M    1000000    3
 
-Clock Speed 5M Should Succeed
-    [Documentation]  Checks the clock speed for 5MHz
-    SPI Clock Speed Check      5M    5000000    1
+Clock Speed 5M Should Succeed 2 Byte
+    [Documentation]  Checks the clock speed for 5MHz with 2 bytes
+    SPI Clock Speed Check Setup      5M    5000000    2
 
-Clock Speed 5M Should Succeed 8 Byte
-    [Documentation]  Checks the clock speed for 5MHz
-    SPI Clock Speed Check      5M    5000000    8
+Clock Speed 5M Should Succeed 3 Byte
+    [Documentation]  Checks the clock speed for 5MHz with 3 bytes
+    SPI Clock Speed Check Setup      5M    5000000    3
 
-Clock Speed 10M Should Succeed
-    [Documentation]  Checks the clock speed for 10MHz
-    SPI Clock Speed Check     10M   10000000    1
+Clock Speed 10M Should Succeed 2 Byte
+    [Documentation]  Checks the clock speed for 10MHz with 2 bytes
+    SPI Clock Speed Check Setup     10M   10000000    2
 
-Clock Speed 10M Should Succeed 8 Byte
-    [Documentation]  Checks the clock speed for 10MHz
-    SPI Clock Speed Check     10M   10000000    8
+Clock Speed 10M Should Succeed 3 Byte
+    [Documentation]  Checks the clock speed for 10MHz with 3 bytes
+    SPI Clock Speed Check Setup     10M   10000000    3

--- a/tests/periph_spi/tests/test_vars.py
+++ b/tests/periph_spi/tests/test_vars.py
@@ -1,8 +1,8 @@
 def str_4():
-	result = ""
-	for i in range(3, 16 + 3):
-	    result += str(i) + " "
-	return result
+    result = ""
+    for i in range(3, 16 + 3):
+        result += str(i) + " "
+    return result
 
 LIST__VAL_1 = [254]
 LIST__VAL_2 = [41]
@@ -19,25 +19,49 @@ LIST__VAL_9 = [254, 7, 8, 9, 10]
 LIST__VAL_10 = [254, 11, 2, 14, 5]
 
 
-def spi_speed_limits(spi_speed, sys_clock_speed, bytes):
+WARN_TOLERANCE = 0.2 #in percentage
+FAIL_TOLERANCE = 0.5 #in percentage
+SEC_TO_USEC = 1000000
+BITS_PER_BYTE = 8
+DEADTIME_TOLERANCE_PER_BIT = 2 / BITS_PER_BYTE #in us, due to possible DUT preparation between bytes
 
-	for i in range(2):
-		if i == 0:
-			spi_speed_limit = spi_speed * 1.20
-		else:
-			spi_speed_limit = spi_speed * 0.8
+def spi_speed_comparison(expected_freq, measured_ticks, sys_clock_speed):
+    expected_freq = int(expected_freq)
+    measured_ticks = int(measured_ticks)
+    sys_clock_speed = int(sys_clock_speed)
 
-		expected_byte_ticks = round((8 * sys_clock_speed) / spi_speed_limit)
-		expected_frame_ticks = expected_byte_ticks * bytes
-		error_tol = round(expected_byte_ticks * bytes / 8)
+    if measured_ticks == 0:
+       raise ValueError("measured ticks cannot be 0")
 
-		if i == 0:
-			lower_limit = expected_frame_ticks - error_tol
-		else:
-			upper_limit = expected_frame_ticks + error_tol
+    measured_time = ticks_to_us(measured_ticks, sys_clock_speed)
+    measured_freq = int(SEC_TO_USEC / (measured_time / (BITS_PER_BYTE)))
 
-	return [lower_limit, upper_limit]
+    result = {}
+    result['pass'] = False
+    result['warn'] = False
+    result['measured_freq'] = measured_freq
+    result['difference_percentage'] = 0
+
+    warn_limits = calculate_limits(expected_freq, WARN_TOLERANCE)
+    fail_limits = calculate_limits(expected_freq, FAIL_TOLERANCE)
+
+    if measured_freq >= fail_limits['lower_limit'] and measured_freq <= fail_limits['upper_limit']:
+        result['pass'] = True
+        if measured_freq < warn_limits['lower_limit'] or measured_freq > warn_limits['upper_limit']:
+            result['warn'] = True
+
+    result['difference_percentage'] = round((measured_freq - expected_freq) / expected_freq * 100, 2)
+
+    return result
 
 
-def convert_ticks_to_us(ticks, sys_clock_speed):
-	return round(ticks / sys_clock_speed * 1000000, 3)
+def calculate_limits(expected_freq, tolerance):
+    result = {}
+    result['lower_limit'] = int(SEC_TO_USEC / (1 / (expected_freq * (1 - tolerance)) * SEC_TO_USEC + DEADTIME_TOLERANCE_PER_BIT))
+    result['upper_limit'] = int(expected_freq * (1 + tolerance))
+    return result
+
+
+def ticks_to_us(ticks, sys_clock_speed):
+    sToUs = 1000000
+    return round(ticks / sys_clock_speed * sToUs, 3)


### PR DESCRIPTION
This introduces the following changes:

- Tests where the time is off limits but are otherwise successful are no longer failing but give a warning instead. 
- The 1 Byte tests were changed to 2 Bytes since there were problems with 1 Byte and 10MHz which always resulted in a measurement of 0.0us
- The measured times as well as the upper and lower limits are now logged to the xunit.xml
- Improved readability