### PR TITLE
tests/periph_gpio: Adapt reset test to not sleep just 1 second

### DIFF
--- a/tests/periph_gpio/tests/03__periph_gpio_reset.robot
+++ b/tests/periph_gpio/tests/03__periph_gpio_reset.robot
@@ -21,5 +21,4 @@ Verify Reset Pin Is Connected
     API Call Should Timeout     lock
     API Call Should Timeout     get_metadata
     Run Keyword                 RIOT Reset
-    Sleep                       1
-    API Call Should Succeed     get_metadata
+    API Sync Shell


### PR DESCRIPTION
Changes out sleep and the get_metadata call to the given API Sync Shell keyword. This does basically the same but gives more time to boards that need it after resetting.