### PR TITLE
tests/periph_i2c: Fix acquire api

### DIFF
--- a/tests/periph_i2c/main.c
+++ b/tests/periph_i2c/main.c
@@ -101,12 +101,9 @@ int cmd_i2c_acquire(int argc, char **argv)
         return -ENODEV;
     }
     printf("Command: i2c_acquire(%i)\n", dev);
-    res = i2c_acquire(dev);
-    if (res == I2C_ACK) {
-        printf("Success: i2c_%i acquired\n", dev);
-        return 0;
-    }
-    return _print_i2c_error(res);
+    i2c_acquire(dev);
+    printf("Success: i2c_%i acquired\n", dev);
+    return 0;
 }
 
 int cmd_i2c_release(int argc, char **argv)


### PR DESCRIPTION
The RIOT API changed... This means that the test must be adapted...