### PR TITLE
SPI clk speed tests with PHiLIP 1.3.0

### DIFF
--- a/tests/periph_spi/tests/04__periph_spi_timer.robot
+++ b/tests/periph_spi/tests/04__periph_spi_timer.robot
@@ -31,9 +31,6 @@ SPI Clock Speed Check Setup
     API Call Should Succeed             PHiLIP.Read Reg     sys.sys_clk
     Set Test Variable                   ${sys_clk}          ${RESULT['data']}
     ${frame_stats}=                     PHiLIP.Get Spi Clk Frame Stats
-    IF  ${frame_stats} == 0
-        Fail  Measurement error. No measurement data.
-    END
 
     Set Test Variable                   ${comparison}
     ...                                     ${spi_speed_comparison(${clk_speed_value}, ${frame_stats}, ${sys_clk}, ${size})}
@@ -42,10 +39,6 @@ SPI Clock Speed Check Setup
     Record Property     measured_freq   ${comparison['measured_freq']}
     Record Property     diff_pct        ${comparison['difference_percentage']}
     Record Property     byte_count      ${size}
-
-    IF  ${comparison['byte_error']}
-        Fail  Measurement error. Expected byte count is ${size}. Actual byte count is ${comparison['byte_count']}
-    END
 
     IF   not ${comparison['pass']}
         Run Keyword
@@ -65,42 +58,50 @@ Fail Test
 
 
 *** Test Cases ***
+Clock Speed 100k Should Succeed 1 Byte
+    [Documentation]  Checks the clock speed for 100kHz with 1 bytes
+    SPI Clock Speed Check Setup    100k     100000    1
+
 Clock Speed 100k Should Succeed 2 Byte
     [Documentation]  Checks the clock speed for 100kHz with 2 bytes
     SPI Clock Speed Check Setup    100k     100000    2
 
-Clock Speed 100k Should Succeed 3 Byte
-    [Documentation]  Checks the clock speed for 100kHz with 3 bytes
-    SPI Clock Speed Check Setup    100k     100000    3
+Clock Speed 100k Should Succeed 8 Byte
+    [Documentation]  Checks the clock speed for 100kHz with 8 bytes
+    SPI Clock Speed Check Setup    100k     100000    8
+
+Clock Speed 400k Should Succeed 1 Byte
+    [Documentation]  Checks the clock speed for 400kHz with 1 bytes
+    SPI Clock Speed Check Setup    400k     400000    1
 
 Clock Speed 400k Should Succeed 2 Byte
     [Documentation]  Checks the clock speed for 400kHz with 2 bytes
     SPI Clock Speed Check Setup    400k     400000    2
 
-Clock Speed 400k Should Succeed 3 Byte
-    [Documentation]  Checks the clock speed for 400kHz with 3 bytes
-    SPI Clock Speed Check Setup    400k     400000    3
+Clock Speed 400k Should Succeed 8 Byte
+    [Documentation]  Checks the clock speed for 400kHz with 8 bytes
+    SPI Clock Speed Check Setup    400k     400000    8
+
+Clock Speed 1M Should Succeed 1 Byte
+    [Documentation]  Checks the clock speed for 1MHz with 1 bytes
+    SPI Clock Speed Check Setup      1M    1000000    1
 
 Clock Speed 1M Should Succeed 2 Byte
     [Documentation]  Checks the clock speed for 1MHz with 2 bytes
     SPI Clock Speed Check Setup      1M    1000000    2
 
-Clock Speed 1M Should Succeed 3 Byte
-    [Documentation]  Checks the clock speed for 1MHz with 3 bytes
-    SPI Clock Speed Check Setup      1M    1000000    3
+Clock Speed 1M Should Succeed 8 Byte
+    [Documentation]  Checks the clock speed for 1MHz with 8 bytes
+    SPI Clock Speed Check Setup      1M    1000000    8
+
+Clock Speed 5M Should Succeed 1 Byte
+    [Documentation]  Checks the clock speed for 5MHz with 1 bytes
+    SPI Clock Speed Check Setup      5M    5000000    1
 
 Clock Speed 5M Should Succeed 2 Byte
     [Documentation]  Checks the clock speed for 5MHz with 2 bytes
     SPI Clock Speed Check Setup      5M    5000000    2
 
-Clock Speed 5M Should Succeed 3 Byte
-    [Documentation]  Checks the clock speed for 5MHz with 3 bytes
-    SPI Clock Speed Check Setup      5M    5000000    3
-
-Clock Speed 10M Should Succeed 2 Byte
-    [Documentation]  Checks the clock speed for 10MHz with 2 bytes
-    SPI Clock Speed Check Setup     10M   10000000    2
-
-Clock Speed 10M Should Succeed 3 Byte
-    [Documentation]  Checks the clock speed for 10MHz with 3 bytes
-    SPI Clock Speed Check Setup     10M   10000000    3
+Clock Speed 5M Should Succeed 8 Byte
+    [Documentation]  Checks the clock speed for 5MHz with 8 bytes
+    SPI Clock Speed Check Setup      5M    5000000    8

--- a/tests/periph_spi/tests/test_vars.py
+++ b/tests/periph_spi/tests/test_vars.py
@@ -19,28 +19,31 @@ LIST__VAL_9 = [254, 7, 8, 9, 10]
 LIST__VAL_10 = [254, 11, 2, 14, 5]
 
 
-WARN_TOLERANCE = 0.2 #in percentage
+WARN_TOLERANCE = 0.1 #in percentage
 FAIL_TOLERANCE = 0.5 #in percentage
 SEC_TO_USEC = 1000000
 BITS_PER_BYTE = 8
-DEADTIME_TOLERANCE_PER_BIT = 2 / BITS_PER_BYTE #in us, due to possible DUT preparation between bytes
 
-def spi_speed_comparison(expected_freq, measured_ticks, sys_clock_speed):
+#compares the measured frequenzy with the expected one
+#Flags are set for a 'pass' and 'warning' state
+def spi_speed_comparison(expected_freq, frame_stats, sys_clock_speed, size):
     expected_freq = int(expected_freq)
-    measured_ticks = int(measured_ticks)
     sys_clock_speed = int(sys_clock_speed)
+    size = int(size)
 
-    if measured_ticks == 0:
-       raise ValueError("measured ticks cannot be 0")
-
-    measured_time = ticks_to_us(measured_ticks, sys_clock_speed)
-    measured_freq = int(SEC_TO_USEC / (measured_time / (BITS_PER_BYTE)))
+    measured_freq = frame_stats['mean']
+    measured_byte_count =  len(frame_stats['values'])
 
     result = {}
     result['pass'] = False
     result['warn'] = False
     result['measured_freq'] = measured_freq
     result['difference_percentage'] = 0
+    result['byte_count'] = measured_byte_count
+    if measured_byte_count != size:
+        result['byte_error'] = True
+    else:
+        result['byte_error'] = False
 
     warn_limits = calculate_limits(expected_freq, WARN_TOLERANCE)
     fail_limits = calculate_limits(expected_freq, FAIL_TOLERANCE)
@@ -54,14 +57,14 @@ def spi_speed_comparison(expected_freq, measured_ticks, sys_clock_speed):
 
     return result
 
-
+#Calculates the lower and upper limits for a frequenzy with a given tolerance 
 def calculate_limits(expected_freq, tolerance):
     result = {}
-    result['lower_limit'] = int(SEC_TO_USEC / (1 / (expected_freq * (1 - tolerance)) * SEC_TO_USEC + DEADTIME_TOLERANCE_PER_BIT))
+    result['lower_limit'] = int(SEC_TO_USEC / (1 / (expected_freq * (1 - tolerance)) * SEC_TO_USEC))
     result['upper_limit'] = int(expected_freq * (1 + tolerance))
     return result
 
-
+#Converts ticks to mikroseconds
 def ticks_to_us(ticks, sys_clock_speed):
     sToUs = 1000000
     return round(ticks / sys_clock_speed * sToUs, 3)

--- a/tests/periph_spi/tests/test_vars.py
+++ b/tests/periph_spi/tests/test_vars.py
@@ -24,8 +24,6 @@ FAIL_TOLERANCE = 0.5 #in percentage
 SEC_TO_USEC = 1000000
 BITS_PER_BYTE = 8
 
-#compares the measured frequenzy with the expected one
-#Flags are set for a 'pass' and 'warning' state
 def spi_speed_comparison(expected_freq, frame_stats, sys_clock_speed, size):
     expected_freq = int(expected_freq)
     sys_clock_speed = int(sys_clock_speed)
@@ -33,6 +31,7 @@ def spi_speed_comparison(expected_freq, frame_stats, sys_clock_speed, size):
 
     measured_freq = frame_stats['mean']
     measured_byte_count =  len(frame_stats['values'])
+    assert measured_byte_count == size, 'Expected byte count does not match measured byte count'
 
     result = {}
     result['pass'] = False
@@ -40,10 +39,6 @@ def spi_speed_comparison(expected_freq, frame_stats, sys_clock_speed, size):
     result['measured_freq'] = measured_freq
     result['difference_percentage'] = 0
     result['byte_count'] = measured_byte_count
-    if measured_byte_count != size:
-        result['byte_error'] = True
-    else:
-        result['byte_error'] = False
 
     warn_limits = calculate_limits(expected_freq, WARN_TOLERANCE)
     fail_limits = calculate_limits(expected_freq, FAIL_TOLERANCE)
@@ -57,14 +52,12 @@ def spi_speed_comparison(expected_freq, frame_stats, sys_clock_speed, size):
 
     return result
 
-#Calculates the lower and upper limits for a frequenzy with a given tolerance 
 def calculate_limits(expected_freq, tolerance):
     result = {}
     result['lower_limit'] = int(SEC_TO_USEC / (1 / (expected_freq * (1 - tolerance)) * SEC_TO_USEC))
     result['upper_limit'] = int(expected_freq * (1 + tolerance))
     return result
 
-#Converts ticks to mikroseconds
 def ticks_to_us(ticks, sys_clock_speed):
     sToUs = 1000000
     return round(ticks / sys_clock_speed * sToUs, 3)


### PR DESCRIPTION
With updated PHiLIP 1.3.0 there are now functionalities to evaluate the measured clk speed more accurate by making use of captured timestamps of the SPI CLK pin and filtering dead times between bytes.
This measurement can only support speeds up to 5MHz therefore the tests were adapted and the 10MHz tests were removed.